### PR TITLE
chore(python): refactor legislative scrapers

### DIFF
--- a/python/scrape_AR.py
+++ b/python/scrape_AR.py
@@ -1,100 +1,149 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape voting act summaries from the Argentine Senate (Senado de la Nación).
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Walks numeric act detail IDs on https://www.senado.gob.ar/votaciones/detalleActa/{id},
+parses each page for title, description, and the first linked document URL, then
+prints a JSON object mapping title to multiline description (stdout).
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
-import sys
-#import numpy as np
+Dependencies: beautifulsoup4 (see https://pypi.org/project/beautifulsoup4/)
+"""
+
+from __future__ import annotations
 
 import json
+import ssl
+import urllib.error
+import urllib.request
+from bs4 import BeautifulSoup
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+# Approximate ID near start of 2026 session window; script walks upward from here.
+START_ACTA_ID = 2600
+MAX_ITEMS = 20
+MAX_CONSECUTIVE_FAILURES = 10
 
-output = {}
+ROOT_URL = "https://www.senado.gob.ar"
+DETALLE_ACTA_PATH = "/votaciones/detalleActa/"
 
-# URl needs to be dynamic
-import datetime
-today = datetime.datetime.now()
-stop = False
-# Global ID 2615 is approx start of 2026
-start = 2600 
-errorcount = 0
-max_errors = 10
-rooturl = 'https://www.senado.gob.ar'
 
-while not stop and len(output) < 20:
-    url = rooturl+'/votaciones/detalleActa/'+str(start)
+def create_unverified_ssl_context() -> ssl.SSLContext:
+    """SSL context that skips certificate verification.
+
+    Some environments fail to verify this host against the local trust store.
+    Skipping verification weakens protection against MITM; use only for this
+    known public scrape if you accept that tradeoff.
+    """
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def fetch_html(url: str, ssl_context: ssl.SSLContext) -> bytes | None:
+    """GET *url* and return response body, or None on HTTP 404."""
     try:
-        html = urllib.request.urlopen(url, context=ctx).read()
-    except urllib.error.HTTPError as e:
-        if e.getcode() == 404: # check the return code
-            errorcount += 1
-            start += 1
-            if errorcount >= max_errors:
+        with urllib.request.urlopen(url, context=ssl_context) as response:
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def parse_acta_entry(soup: BeautifulSoup, root_url: str) -> tuple[str, str] | None:
+    """Extract (title, description) from an act detail page, or None if not parseable."""
+    section = soup.find("div", {"class": "col-lg-6 col-sm-6"})
+    if not section:
+        return None
+
+    paragraphs = section.find_all("p")
+    if len(paragraphs) <= 1:
+        return None
+
+    topic_el = paragraphs[1]
+    topic = topic_el.get_text().strip().replace("\n", "").replace("\xa0", " ")
+    if len(topic) < 4:
+        return None
+
+    parts = topic.split(". ", 1)
+    topic_clean = [p.strip() for p in parts if p.strip()]
+    if len(topic_clean) < 2:
+        return None
+
+    title = topic_clean[0].replace("\xa0", " ")
+    doc_id = _normalize_whitespace(topic_clean[1])
+
+    if "(" not in doc_id:
+        title = f"{doc_id} - {title}"
+
+    desc = f"{topic_clean[0]}\n{topic_clean[1]}"
+    desc = _normalize_whitespace(desc).replace("( ", "")
+
+    href = ""
+    for link in topic_el.find_all("a"):
+        link_href = link.get("href")
+        if link_href:
+            href = root_url + link_href
+            desc = f"{desc}\n{href}"
+
+    if not href:
+        return None
+
+    return title, desc
+
+
+def scrape_actas(
+    *,
+    start_id: int = START_ACTA_ID,
+    max_items: int = MAX_ITEMS,
+    max_consecutive_failures: int = MAX_CONSECUTIVE_FAILURES,
+    root_url: str = ROOT_URL,
+    ssl_context: ssl.SSLContext | None = None,
+) -> dict[str, str]:
+    """Collect up to *max_items* act entries by incrementing act IDs from *start_id*."""
+    ctx = ssl_context or create_unverified_ssl_context()
+    results: dict[str, str] = {}
+    acta_id = start_id
+    consecutive_failures = 0
+    stop = False
+
+    while not stop and len(results) < max_items:
+        url = f"{root_url}{DETALLE_ACTA_PATH}{acta_id}"
+        html = fetch_html(url, ctx)
+
+        if html is None:
+            consecutive_failures += 1
+            acta_id += 1
+            if consecutive_failures >= max_consecutive_failures:
                 stop = True
             continue
-        raise # if other than 404, raise the error
 
-    soup = BeautifulSoup(html, 'html.parser')
+        soup = BeautifulSoup(html, "html.parser")
+        parsed = parse_acta_entry(soup, root_url)
 
-    section = ""
-    section = soup.find("div", {'class': 'col-lg-6 col-sm-6'})
-    if not section:
-        errorcount += 1
-        start += 1
-        if errorcount >= max_errors:
-            stop = True
-        continue
-
-    ps = section.find_all('p')
-    if len(ps) > 1:
-        topic = ps[1].get_text().strip()
-        topic = topic.replace("\n", "")
-        topic = topic.replace(u'\xa0', u' ')
-        if len(str(topic)) < 4:
-            errorcount += 1
-            start += 1
+        if parsed is None:
+            consecutive_failures += 1
+            acta_id += 1
+            if consecutive_failures >= max_consecutive_failures:
+                stop = True
             continue
-    else:
-        errorcount += 1
-        start += 1
-        continue
 
-    topic_split = topic.split(". ", 1)
-    topic_clean = [t.strip() for t in topic_split if t.strip() != ""]
-    title = topic_clean[0].replace(u'\xa0', u' ')
+        title, desc = parsed
+        results[title] = desc
+        consecutive_failures = 0
+        acta_id += 1
 
-    if len(topic_clean) > 1:
-        doc_id = topic_clean[1]
-        doc_id = " ".join(doc_id.split())
-        if '(' not in doc_id:
-            title = doc_id + ' - ' + title
-        desc = topic_clean[0] + "\n" + topic_clean[1]
-        desc = " ".join(desc.split()).replace("( ", "")
+    return results
 
-        href = ''
-        for links in ps[1].findAll('a'):
-            link_href = links.get('href')
-            if link_href:
-                href = rooturl + link_href
-                desc = desc + "\n" + href
 
-        if href:
-            output[title] = desc
-            # successful scrape
-            errorcount = 0
+def main() -> None:
+    output = scrape_actas()
+    print(json.dumps(output))
 
-    start += 1
 
-print(json.dumps(output))
+if __name__ == "__main__":
+    main()

--- a/python/scrape_AU.py
+++ b/python/scrape_AU.py
@@ -1,123 +1,149 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape Australian Parliament bill search result pages by bill id.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Walks aph.gov.au bill pages, keeps those with first-reading dates in roughly the
+last 90 days, and prints JSON mapping title to summary plus page URL.
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
-import sys
-#import numpy as np
+Dependencies: beautifulsoup4, requests, urllib3
+"""
 
-import json
-import requests
-import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-from bs4 import BeautifulSoup
-import ssl
+from __future__ import annotations
+
 import datetime
+import json
 import time
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+import requests
+import urllib3
+from bs4 import BeautifulSoup
 
-output = {}
+ROOT_URL = (
+    "https://www.aph.gov.au/Parliamentary_Business/Bills_Legislation/"
+    "Bills_Search_Results/Result?bId=r"
+)
+START_BILL_ID = 7350
+MAX_ITEMS = 20
+MAX_CONSECUTIVE_ERRORS = 10
+REQUEST_TIMEOUT = 15
+RECENT_DAYS = 90
+REQUEST_DELAY_SEC = 0.5
 
-header = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-}
 
-today = datetime.datetime.now()
-three_months_ago = today - datetime.timedelta(days=90)
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-stop = False
-# start = 6721 # Old start
-start = 7350 # Targeted start for 2026 bills
-errorcount = 0
-max_consecutive_errors = 10
-rooturl = 'https://www.aph.gov.au/Parliamentary_Business/Bills_Legislation/Bills_Search_Results/Result?bId=r'
 
-while not stop and len(output) < 20:
-    url = rooturl + str(start)
-    try:
-        response = requests.get(url, headers=header, timeout=15, verify=False)
-        if response.status_code == 404:
-            errorcount += 1
-            start += 1
-            if errorcount >= max_consecutive_errors:
+def scrape_aph_bills() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    today = datetime.datetime.now()
+    cutoff = today - datetime.timedelta(days=RECENT_DAYS)
+    output: dict[str, str] = {}
+
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+        )
+    }
+
+    bill_id = START_BILL_ID
+    consecutive_errors = 0
+    stop = False
+
+    while not stop and len(output) < MAX_ITEMS:
+        url = f"{ROOT_URL}{bill_id}"
+        try:
+            response = requests.get(
+                url,
+                headers=headers,
+                timeout=REQUEST_TIMEOUT,
+                verify=False,
+            )
+        except requests.RequestException:
+            consecutive_errors += 1
+            if consecutive_errors >= MAX_CONSECUTIVE_ERRORS:
                 stop = True
+            bill_id += 1
+            time.sleep(REQUEST_DELAY_SEC)
+            continue
+
+        if response.status_code == 404:
+            consecutive_errors += 1
+            bill_id += 1
+            if consecutive_errors >= MAX_CONSECUTIVE_ERRORS:
+                stop = True
+            time.sleep(REQUEST_DELAY_SEC)
             continue
 
         if response.status_code != 200:
-            errorcount += 1
-            start += 1
+            consecutive_errors += 1
+            bill_id += 1
+            time.sleep(REQUEST_DELAY_SEC)
             continue
 
-        soup = BeautifulSoup(response.text, 'html.parser')
-
-        # Get Title
-        header_div = soup.find("div", {'id': 'main_0_billSummary_divHeader'})
+        soup = BeautifulSoup(response.text, "html.parser")
+        header_div = soup.find("div", {"id": "main_0_billSummary_divHeader"})
         title = ""
         if header_div:
-            h1 = header_div.find('h1')
+            h1 = header_div.find("h1")
             if h1:
                 title = h1.get_text().strip()
 
         if not title:
-            errorcount += 1
-            start += 1
+            consecutive_errors += 1
+            bill_id += 1
+            time.sleep(REQUEST_DELAY_SEC)
             continue
 
-        # Check Date
-        # Find "Introduced and read a first time" and the following <td>
         is_recent = False
-        intro_tag = soup.find(string=lambda text: text and "Introduced and read a first time" in text)
+        intro_tag = soup.find(
+            string=lambda text: text and "Introduced and read a first time" in text
+        )
         if intro_tag:
-            parent_tr = intro_tag.find_parent('tr')
+            parent_tr = intro_tag.find_parent("tr")
             if parent_tr:
-                date_td = parent_tr.find_all('td')[1]
-                if date_td:
+                tds = parent_tr.find_all("td")
+                if len(tds) > 1:
+                    date_td = tds[1]
                     date_str = date_td.get_text().strip()
                     try:
-                        # Example format: 21 Nov 2024
                         intro_date = datetime.datetime.strptime(date_str, "%d %b %Y")
-                        if intro_date >= three_months_ago:
+                        if intro_date >= cutoff:
                             is_recent = True
-                    except:
+                    except ValueError:
                         pass
 
         if not is_recent:
-            start += 1
-            errorcount = 0 # It's a valid page, just too old
+            bill_id += 1
+            consecutive_errors = 0
+            time.sleep(REQUEST_DELAY_SEC)
             continue
 
-        # Get Summary
-        summary_panel = soup.find("div", {'id': 'main_0_summaryPanel'})
+        summary_panel = soup.find("div", {"id": "main_0_summaryPanel"})
         desc = ""
         if summary_panel:
-            ps = summary_panel.find_all('p')
+            ps = summary_panel.find_all("p")
             if ps:
                 desc = ps[0].get_text().strip()
 
         if desc:
             desc = desc + "\n" + url
             output[title] = desc
-            errorcount = 0 # reset error count on success
+            consecutive_errors = 0
 
-    except Exception as e:
-        errorcount += 1
+        bill_id += 1
+        time.sleep(REQUEST_DELAY_SEC)
 
-    if errorcount >= max_consecutive_errors:
-        stop = True
+        if consecutive_errors >= MAX_CONSECUTIVE_ERRORS:
+            stop = True
 
-    start += 1
-    time.sleep(0.5) # Be nice to their server
+    return output
 
-print(json.dumps(output))
+
+def main() -> None:
+    print(json.dumps(scrape_aph_bills()))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_BR.py
+++ b/python/scrape_BR.py
@@ -1,70 +1,97 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape recent Camara dos Deputados (Brazil) proposals via the open data API.
+
+Filters PL/PEC types for the current year and roughly the last 90 days, then
+prints JSON mapping a composite title to ementa and portal URL.
+
+Dependencies: requests, urllib3
+"""
+
+from __future__ import annotations
+
+import datetime
 import json
+
 import requests
 import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import datetime
-import ssl
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+API_URL = "https://dadosabertos.camara.leg.br/api/v2/proposicoes"
+REQUEST_TIMEOUT = 15
+RECENT_DAYS = 90
 
-output = {}
 
-today = datetime.datetime.now()
-three_months_ago = today - datetime.timedelta(days=90)
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-# Filter for PL (Projeto de Lei) and PEC (Proposta de Emenda à Constituição)
-# We can fetch multiple pages if needed, but 50 results is usually enough for "last 3 months"
-url = "https://dadosabertos.camara.leg.br/api/v2/proposicoes"
-params = {
-    "ano": today.year,
-    "ordem": "DESC",
-    "ordenarPor": "id",
-    "itens": 50,
-    "siglaTipo": ["PL", "PEC"]
-}
 
-header = {
-    "accept": "application/json",
-    "User-Agent": "Mozilla/5.0"
-}
+def scrape_camara_proposicoes() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    today = datetime.datetime.now()
+    cutoff = today - datetime.timedelta(days=RECENT_DAYS)
+    output: dict[str, str] = {}
 
-try:
-    response = requests.get(url, params=params, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
+    params = {
+        "ano": today.year,
+        "ordem": "DESC",
+        "ordenarPor": "id",
+        "itens": 50,
+        "siglaTipo": ["PL", "PEC"],
+    }
+    headers = {
+        "accept": "application/json",
+        "User-Agent": "Mozilla/5.0",
+    }
+
+    try:
+        response = requests.get(
+            API_URL,
+            params=params,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+    except requests.RequestException:
+        return output
+
+    if response.status_code != 200:
+        return output
+
+    try:
         data = response.json()
-        for item in data.get('dados', []):
-            # Parse presentation date: "2026-03-06T18:39"
-            date_str = item.get('dataApresentacao', '')
-            try:
-                # Using only the date part for comparison
-                item_date = datetime.datetime.strptime(date_str.split('T')[0], "%Y-%m-%d")
-                if item_date >= three_months_ago:
-                    bill_ref = f"{item.get('siglaTipo')} {item.get('numero')}/{item.get('ano')}"
-                    ementa = item.get('ementa', '').strip()
-                    
-                    # Create a descriptive title: Bill Ref + start of ementa
-                    # Truncate ementa for title if it's too long
-                    title_desc = ementa
-                    if len(title_desc) > 150:
-                        title_desc = title_desc[:147] + "..."
-                    
-                    title = f"{bill_ref}: {title_desc}"
-                    
-                    # Fix Link: The API provides 'uri' for data, but we want the public portal
-                    # The most reliable public link is often the "Inteiro Teor" (Full Text) or the search detail
-                    prop_id = item.get('id')
-                    # This is the modern portal link format
-                    link = f"https://www.camara.leg.br/propostas-legislativas/{prop_id}"
-                    
-                    desc = f"{ementa}\nSource: {link}"
-                    output[title] = desc
-            except Exception as e:
-                continue
-except Exception as e:
-    pass
+    except ValueError:
+        return output
 
-print(json.dumps(output))
+    for item in data.get("dados", []):
+        date_str = item.get("dataApresentacao", "")
+        try:
+            item_date = datetime.datetime.strptime(
+                date_str.split("T")[0],
+                "%Y-%m-%d",
+            )
+        except (ValueError, IndexError):
+            continue
+        if item_date < cutoff:
+            continue
+
+        bill_ref = f"{item.get('siglaTipo')} {item.get('numero')}/{item.get('ano')}"
+        ementa = (item.get("ementa") or "").strip()
+        title_desc = ementa
+        if len(title_desc) > 150:
+            title_desc = title_desc[:147] + "..."
+
+        title = f"{bill_ref}: {title_desc}"
+        prop_id = item.get("id")
+        link = f"https://www.camara.leg.br/propostas-legislativas/{prop_id}"
+        desc = f"{ementa}\nSource: {link}"
+        output[title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_camara_proposicoes()))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_CA.py
+++ b/python/scrape_CA.py
@@ -1,70 +1,60 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape Canadian Parliament bill metadata from the LegisINFO XML feed.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Builds a JSON object keyed by short title (falling back to long title) with
+description including the long title and public bill URL.
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
-import sys
-import requests
-import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import re
-#import numpy as np
+Dependencies: beautifulsoup4, requests, urllib3
+"""
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+from __future__ import annotations
 
 import json
 
-# ... (keep existing imports and setup)
+import requests
+import urllib3
+from bs4 import BeautifulSoup, Tag
 
-output = {}
-
-# Read the XML file
-url = 'https://www.parl.ca/legisinfo/en/bills/xml'
-xml = requests.get(url, verify=False)
-soup = BeautifulSoup(xml.content, features='xml')
-bills = soup.find_all("Bill")
-for bill in bills:
-    title = bill.find("ShortTitleEn").getText()
-    desc = bill.find("LongTitleEn").getText()
-    session = bill.find("ParlSessionCode").getText()
-    code = bill.find("BillNumberFormatted").getText()
-
-    link = "https://www.parl.ca/legisinfo/en/bill/"+session+"/"+code
-    
-    if title == '\n':
-        title = desc
-    desc = desc + "\n" + link 
-    output[title] = desc
-
-print(json.dumps(output))
-
-#print(topicno)
-#print(status)
-#print(url)
-#print(uzeit) 
-#list_of_contents.remove("\n")
-#list_of_contents.remove(" ")
+XML_URL = "https://www.parl.ca/legisinfo/en/bills/xml"
+REQUEST_TIMEOUT = 30
 
 
-#print(list_of_contents)
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-#print(topiclist)
 
-#f = open('BT_Tagesordnung.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in output))
-#f.close
+def _text(el: Tag | None) -> str:
+    return el.getText() if el else ""
 
-#f = open('BT_Tagesordnung.txt', 'a')
-#f.write("\n".join(str(item) for item in url))
-#f.close
+
+def scrape_parl_ca_bills() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+
+    response = requests.get(XML_URL, timeout=REQUEST_TIMEOUT, verify=False)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.content, features="xml")
+    for bill in soup.find_all("Bill"):
+        title = _text(bill.find("ShortTitleEn"))
+        desc = _text(bill.find("LongTitleEn"))
+        session = _text(bill.find("ParlSessionCode"))
+        code = _text(bill.find("BillNumberFormatted"))
+        link = f"https://www.parl.ca/legisinfo/en/bill/{session}/{code}"
+
+        if title == "\n":
+            title = desc
+
+        desc = desc + "\n" + link
+        output[title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_parl_ca_bills()))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_CL.py
+++ b/python/scrape_CL.py
@@ -1,69 +1,82 @@
 #!/usr/bin/env python3
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+"""
+Scrape Chile Cámara de Diputados promoted law projects listing.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Parses the HTML table until encountering a row older than one year, and prints
+a flat list of title and description pairs.
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
+Dependencies: beautifulsoup4
+"""
+
+from __future__ import annotations
+
 import ssl
-from datetime import datetime
-from datetime import timedelta
+import urllib.request
+from datetime import datetime, timedelta
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+from bs4 import BeautifulSoup
 
-today = datetime.now()
-output = []
+LIST_URL = "https://www.camara.cl/legislacion/ProyectosDeLey/leyes_promulgadas.aspx"
+DOC_BASE = "https://www.camara.cl/legislacion/ProyectosDeLey/"
 
-url = 'https://www.camara.cl/legislacion/ProyectosDeLey/leyes_promulgadas.aspx'
-docurl = 'https://www.camara.cl/legislacion/ProyectosDeLey/'
-html = urllib.request.urlopen(url, context=ctx).read()
 
-soup = BeautifulSoup(html, 'html.parser')
+def create_unverified_ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
 
-section = soup.find("div", {'class': 'grid-12 lista-proyectos aleft'})
-trs = section.findAll('tr')
 
-for tr in trs:
-    tds = tr.findAll('td')
-    title = []
-    contents = []
-    for id, td in enumerate(tds):          
-            if td.find('a') is not None and id == 0: 
-                contents.append(td.find('a').get('href'))
+def scrape_camara_cl_promulgadas() -> list[str]:
+    ctx = create_unverified_ssl_context()
+    with urllib.request.urlopen(LIST_URL, context=ctx) as response:
+        html = response.read()
+
+    soup = BeautifulSoup(html, "html.parser")
+    section = soup.find("div", {"class": "grid-12 lista-proyectos aleft"})
+    if not section:
+        return []
+
+    output: list[str] = []
+    cutoff = datetime.now() - timedelta(days=365)
+
+    for row in section.find_all("tr"):
+        cells = row.find_all("td")
+        contents: list[str] = []
+        for col_idx, cell in enumerate(cells):
+            anchor = cell.find("a")
+            if anchor is not None and col_idx == 0:
+                href = anchor.get("href")
+                contents.append(href or "")
             else:
-                contents.append(td.getText().split("\n")[0])
-    
-    if contents:
-        title = contents[3].replace(u'\xa0', u' ')
-        title = title.replace("'", " ")
-        link = docurl + contents[0]
+                parts = cell.getText().split("\n")
+                contents.append(parts[0] if parts else "")
+
+        if not contents or len(contents) < 6:
+            continue
+
+        title = contents[3].replace("\xa0", " ").replace("'", " ")
+        link = DOC_BASE + contents[0]
         desc = contents[5] + " \n" + link
         desc = desc.replace("'", " ")
-        date = datetime.strptime(contents[5], "%d-%m-%Y")
-        if date < (datetime.now() - timedelta(days=365)):
+
+        try:
+            row_date = datetime.strptime(contents[5], "%d-%m-%Y")
+        except ValueError:
+            continue
+
+        if row_date < cutoff:
             break
 
         output.append(title)
         output.append(desc)
 
-#print(refs)
-#list_of_contents.reverse()
+    return output
 
-#headings = list_of_contents[0::4]
-#URL = list_of_contents[2::4]
 
-print(output)
-#print(headings)
-#print(URL)
+def main() -> None:
+    print(scrape_camara_cl_promulgadas())
 
-#f = open('UNSC.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in list_of_contents))
-#f.close
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_CZ.py
+++ b/python/scrape_CZ.py
@@ -1,45 +1,79 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape Czech Chamber of Deputies print (tisk) RSS, decoded as Windows-1250.
+
+Filters items heuristically for primary bills and prints JSON (UTF-8 preserved).
+
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import json
-import requests
-from bs4 import BeautifulSoup
-import warnings
-import urllib3
 import re
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+import requests
+import urllib3
+from bs4 import BeautifulSoup
 
-output = {}
-url = "https://www.psp.cz/rss/tisky.rss"
-header = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
-}
+RSS_URL = "https://www.psp.cz/rss/tisky.rss"
+REQUEST_TIMEOUT = 15
+MAX_TITLE_LEN = 250
 
-try:
-    response = requests.get(url, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
-        # Decode from windows-1250/cp1250
-        content_text = response.content.decode('cp1250', errors='replace')
-        
-        # Remove the XML declaration that says windows-1250 to avoid confusing parsers
-        content_text = re.sub(r'<\?xml.*?\?>', '', content_text)
-        
-        soup = BeautifulSoup(content_text, "xml")
-        items = soup.find_all("item")
-        
-        for item in items:
-            title = item.find("title").get_text().strip() if item.find("title") else ""
-            desc = item.find("description").get_text().strip() if item.find("description") else ""
-            link = item.find("link").get_text().strip() if item.find("link") else ""
-            
-            # Filter for primary bills
-            if "/0" in title or "Návrh" in title or "Novela" in title:
-                if len(title) > 250:
-                    title = title[:247] + "..."
-                
-                output[title] = f"{desc}\nSource: {link}"
 
-except Exception:
-    pass
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-print(json.dumps(output, ensure_ascii=False))
+
+def scrape_psp_rss() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
+    }
+
+    try:
+        response = requests.get(
+            RSS_URL,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+    except requests.RequestException:
+        return output
+
+    if response.status_code != 200:
+        return output
+
+    content_text = response.content.decode("cp1250", errors="replace")
+    content_text = re.sub(r"<\?xml.*?\?>", "", content_text)
+
+    soup = BeautifulSoup(content_text, "xml")
+    for item in soup.find_all("item"):
+        title_el = item.find("title")
+        desc_el = item.find("description")
+        link_el = item.find("link")
+        title = title_el.get_text().strip() if title_el else ""
+        desc = desc_el.get_text().strip() if desc_el else ""
+        link = link_el.get_text().strip() if link_el else ""
+
+        if "/0" not in title and "Návrh" not in title and "Novela" not in title:
+            continue
+
+        if len(title) > MAX_TITLE_LEN:
+            title = title[: MAX_TITLE_LEN - 3] + "..."
+
+        output[title] = f"{desc}\nSource: {link}"
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_psp_rss(), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_DE.py
+++ b/python/scrape_DE.py
@@ -1,89 +1,108 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape Bundestag (Germany) plenary vote (Abstimmung) pages by numeric id.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Walks increasing ids from a start value, parses each article for title/description
+and anchor hrefs, and prints a flat list of title, description pairs.
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
+Dependencies: beautifulsoup4
+"""
+
+from __future__ import annotations
+
 import ssl
-import sys
-#import numpy as np
+import urllib.error
+import urllib.request
+from bs4 import BeautifulSoup
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+START_ID = 950
+MAX_CONSECUTIVE_FAILURES = 5
+BASE_URL = "https://www.bundestag.de/parlament/plenum/abstimmung/abstimmung?id="
+USER_AGENT = "Mozilla/5.0 (Linux i686)"
 
-refs = []
-output = []
 
-# URl needs to be dynamic
-import datetime
-today = datetime.datetime.now()
-stop = False
-start = 950
-errorcount = 0
-while not stop:
-    url= urllib.request.Request('https://www.bundestag.de/parlament/plenum/abstimmung/abstimmung?id='+str(start))
-    url.add_header('User-agent', 'Mozilla/5.0 (Linux i686)')
+def create_unverified_ssl_context() -> ssl.SSLContext:
+    """SSL context without verification (same tradeoff as legacy scrapers)."""
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def fetch_abstimmung(act_id: int, ssl_context: ssl.SSLContext) -> bytes | None:
+    """Return HTML body or None on HTTP error (caller treats as failure)."""
+    req = urllib.request.Request(
+        f"{BASE_URL}{act_id}",
+        headers={"User-agent": USER_AGENT},
+    )
     try:
-        html = urllib.request.urlopen(url, context=ctx).read()
-    except urllib.error.HTTPError as e:
-        if e:
-            errorcount += 1
-            start += 1
-            if errorcount == 5:
+        with urllib.request.urlopen(req, context=ssl_context) as response:
+            return response.read()
+    except urllib.error.HTTPError:
+        return None
+
+
+def parse_article(html: bytes) -> tuple[str, str] | None:
+    """Return (title, desc) from a vote page, or None if layout missing."""
+    soup = BeautifulSoup(html, "html.parser")
+    section = soup.find(
+        "article",
+        {"class": "bt-artikel col-xs-12 bt-standard-content"},
+    )
+    if not section:
+        return None
+
+    topic = [t.strip() for t in section.getText().strip().split("\n") if t.strip()]
+    if len(topic) < 3:
+        return None
+
+    title = topic[1].replace("\xa0", " ")
+    desc = topic[2] + " \n" + topic[0]
+
+    for link in section.find_all("a"):
+        href = link.get("href")
+        if href:
+            desc = desc + "\n" + href
+
+    return title, desc
+
+
+def scrape_bundestag_abstimmungen() -> list[str]:
+    """Collect vote summaries until consecutive failures reach the limit."""
+    ctx = create_unverified_ssl_context()
+    output: list[str] = []
+    act_id = START_ID
+    consecutive_failures = 0
+    stop = False
+
+    while not stop:
+        html = fetch_abstimmung(act_id, ctx)
+        if html is None:
+            consecutive_failures += 1
+            act_id += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
                 stop = True
             continue
 
-    soup = BeautifulSoup(html, 'html.parser')
+        parsed = parse_article(html)
+        if parsed is None:
+            consecutive_failures += 1
+            act_id += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                stop = True
+            continue
 
-    section = soup.find("article", {'class': 'bt-artikel col-xs-12 bt-standard-content'})
-    if not section:
-        errorcount += 1
-        start += 1
-        if errorcount == 5:
-            stop = True
-        continue
-    
-    topic = section.getText().strip()
-    topic = topic.split("\n")
-    topic = [t.strip() for t in topic if t.strip() != ""]
-    title = topic[1].replace(u'\xa0', u' ')
-    desc = topic[2] + " \n" + topic[0]
-        
-    for links in section.findAll('a'):
-        href = links.get('href')
-        desc = desc + "\n" + href
+        title, desc = parsed
+        output.append(title)
+        output.append(desc)
+        act_id += 1
 
-    output.append(title)
-    output.append(desc)    
-
-    start += 1
-
-print(output)
-
-#print(topicno)
-#print(status)
-#print(url)
-#print(uzeit) 
-#list_of_contents.remove("\n")
-#list_of_contents.remove(" ")
+    return output
 
 
-#print(list_of_contents)
+def main() -> None:
+    print(scrape_bundestag_abstimmungen())
 
-#print(topiclist)
 
-#f = open('BT_Tagesordnung.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in output))
-#f.close
-
-#f = open('BT_Tagesordnung.txt', 'a')
-#f.write("\n".join(str(item) for item in url))
-#f.close
+if __name__ == "__main__":
+    main()

--- a/python/scrape_DK.py
+++ b/python/scrape_DK.py
@@ -1,88 +1,94 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape Danish Folketinget (Ft.dk) bill index pages by bill number.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Determines session year from the calendar (Sep–May session), walks bill ids,
+and prints a flat list of title and index URL pairs.
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
-import sys
-#import numpy as np
+Dependencies: beautifulsoup4
+"""
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+from __future__ import annotations
 
-output = []
-
-# URl needs to be dynamic
 import datetime
-today = datetime.datetime.now()
-if  today.month <= 8:       #voting period is Sep - May 
-    year = today.year - 1
-else:
-    year = today.year
-stop = False
-start = 50
-errorcount = 0
-while not stop:
-    #url = 'https://www.ft.dk/samling/20201/beslutningsforslag/b'+str(start)+'/index.htm'
-    url = 'https://www.ft.dk/samling/'+str(year)+'1/lovforslag/l'+str(start)+'/index.htm'
-    try:
-        html = urllib.request.urlopen(url, context=ctx).read()
-    except urllib.error.HTTPError as e:
-            errorcount += 1
-            start += 1
-            if errorcount == 5:
+import ssl
+import urllib.error
+import urllib.request
+from bs4 import BeautifulSoup
+
+START_BILL = 50
+MAX_CONSECUTIVE_FAILURES = 5
+SAMPLING_PREFIX = "https://www.ft.dk/samling/"
+
+
+def create_unverified_ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def session_year(today: datetime.date | None = None) -> int:
+    """Return Folketinget session start year (Sep–May cycle)."""
+    today = today or datetime.date.today()
+    if today.month <= 8:
+        return today.year - 1
+    return today.year
+
+
+def bill_url(year: int, bill_num: int) -> str:
+    return f"{SAMPLING_PREFIX}{year}1/lovforslag/l{bill_num}/index.htm"
+
+
+def scrape_ft_bills() -> list[str]:
+    ctx = create_unverified_ssl_context()
+    year = session_year()
+    output: list[str] = []
+    bill_num = START_BILL
+    consecutive_failures = 0
+    stop = False
+
+    while not stop:
+        url = bill_url(year, bill_num)
+        try:
+            with urllib.request.urlopen(url, context=ctx) as response:
+                html = response.read()
+        except urllib.error.HTTPError:
+            consecutive_failures += 1
+            bill_num += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
                 stop = True
             continue
 
-    soup = BeautifulSoup(html, 'html.parser')
+        soup = BeautifulSoup(html, "html.parser")
+        section = soup.find("div", {"class": "tingdok"})
+        if not section:
+            consecutive_failures += 1
+            bill_num += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                stop = True
+            continue
 
-    section = soup.find("div", {'class': 'tingdok'})
-    if not section:
-        errorcount += 1
-        start += 1
-        if errorcount == 5:
-            stop = True
-        continue
-    
-    title = ""
-    desc = ""
+        heading = soup.find("h1", {"class": "tingdok-heading"})
+        if not heading:
+            consecutive_failures += 1
+            bill_num += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                stop = True
+            continue
 
-    title = soup.find("h1", {'class': 'tingdok-heading'}).getText().strip()
-    desc = 'https://www.ft.dk/samling/'+str(year)+'1/lovforslag/l'+str(start)+'/index.htm'
+        title = heading.getText().strip()
+        desc = bill_url(year, bill_num)
+        output.append(title)
+        output.append(desc)
+        bill_num += 1
 
-    output.append(title)
-    output.append(desc) 
-    #print(start)   
-
-    start = start + 1
-
-print(output)
-
-#print(topicno)
-#print(status)
-#print(url)
-#print(uzeit) 
-#list_of_contents.remove("\n")
-#list_of_contents.remove(" ")
+    return output
 
 
-#print(list_of_contents)
+def main() -> None:
+    print(scrape_ft_bills())
 
-#print(topiclist)
 
-#f = open('BT_Tagesordnung.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in output))
-#f.close
-
-#f = open('BT_Tagesordnung.txt', 'a')
-#f.write("\n".join(str(item) for item in url))
-#f.close
+if __name__ == "__main__":
+    main()

--- a/python/scrape_ES.py
+++ b/python/scrape_ES.py
@@ -1,109 +1,146 @@
-#!/usr/bin/env python
-import json
-import requests
+#!/usr/bin/env python3
+"""
+Scrape recent Spanish Congress (Congreso) initiatives via portal AJAX endpoints.
+
+POSTs filter payloads for several initiative types, keeps items from roughly the
+last 90 days, and prints JSON (UTF-8, non-ASCII preserved).
+
+Dependencies: requests, urllib3
+"""
+
+from __future__ import annotations
+
 import datetime
-import ssl
+import json
+from typing import Any
+
+import requests
 import urllib3
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+REQUEST_TIMEOUT = 15
+RECENT_DAYS = 90
+MAX_TITLE_LEN = 250
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
-
-output = {}
-
-today = datetime.datetime.now()
-three_months_ago = today - datetime.timedelta(days=90)
-
-header = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
-}
-
-# Sources and their corresponding CINI filters for Spanish Congress
-# 121.CINI. = Proyectos de Ley (Government bills)
-# (proposicion+adj2+ley).tipo. = Proposiciones de Ley (Member bills)
-# 181.CINI. = Preguntas con respuesta oral
-# 184.CINI. = Preguntas con respuesta escrita
-sources = [
-    {
-        "url": "https://www.congreso.es/es/proyectos-de-ley",
-        "cini": "121.CINI."
-    },
+SOURCES: list[dict[str, str]] = [
+    {"url": "https://www.congreso.es/es/proyectos-de-ley", "cini": "121.CINI."},
     {
         "url": "https://www.congreso.es/es/proposiciones-de-ley",
-        "cini": "(proposicion+adj2+ley).tipo."
+        "cini": "(proposicion+adj2+ley).tipo.",
     },
-    {
-        "url": "https://www.congreso.es/es/busqueda-de-iniciativas",
-        "cini": "181.CINI."
-    },
-    {
-        "url": "https://www.congreso.es/es/busqueda-de-iniciativas",
-        "cini": "184.CINI."
-    }
+    {"url": "https://www.congreso.es/es/busqueda-de-iniciativas", "cini": "181.CINI."},
+    {"url": "https://www.congreso.es/es/busqueda-de-iniciativas", "cini": "184.CINI."},
 ]
 
-ajax_base = "?p_p_id=iniciativas&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=filtrarListado&p_p_cacheability=cacheLevelPage"
+AJAX_SUFFIX = (
+    "?p_p_id=iniciativas&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&"
+    "p_p_resource_id=filtrarListado&p_p_cacheability=cacheLevelPage"
+)
 
-for src in sources:
-    ajax_url = src["url"] + ajax_base
-    payload = {
-        "_iniciativas_legislatura": "15",
-        "_iniciativas_estadoTramitacion": "",
-        "_iniciativas_faseTramitacion": "",
-        "_iniciativas_cini": src["cini"],
-        "_iniciativas_tipoLlamada": "T",
-        "_iniciativas_paginaActual": "1"
+
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def _collect_authors(autores_obj: Any) -> str:
+    names: list[str] = []
+    if isinstance(autores_obj, dict):
+        for _key, val in autores_obj.items():
+            if isinstance(val, dict):
+                nombre = val.get("nombre", "")
+                if nombre:
+                    names.append(nombre)
+    return ", ".join(names) if names else "N/A"
+
+
+def scrape_congreso_iniciativas() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    today = datetime.datetime.now()
+    cutoff = today - datetime.timedelta(days=RECENT_DAYS)
+    output: dict[str, str] = {}
+
+    header = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
     }
-    
-    try:
-        response = requests.post(ajax_url, data=payload, headers=header, timeout=15, verify=False)
-        if response.status_code == 200:
-            data = response.json()
-            initiatives = data.get('lista_iniciativas', {})
-            for key in initiatives:
-                item = initiatives[key]
-                date_str = item.get('fecha_presentado', '')
-                if not date_str:
-                    continue
-                
-                try:
-                    # Format: 12/02/2026
-                    item_date = datetime.datetime.strptime(date_str, "%d/%m/%Y")
-                    if item_date >= three_months_ago:
-                        title_raw = item.get('titulo', '').strip()
-                        if not title_raw:
-                            continue
-                        
-                        bill_ref = item.get('id_iniciativa', '')
-                        legislatura = item.get('legislatura', 'XV')
-                        
-                        # Author extraction
-                        autores_obj = item.get('autores', {})
-                        autores_list = []
-                        if isinstance(autores_obj, dict):
-                            for k in autores_obj:
-                                nombre = autores_obj[k].get('nombre', '')
-                                if nombre:
-                                    autores_list.append(nombre)
-                        autor_str = ", ".join(autores_list) if autores_list else "N/A"
-                        
-                        # Create descriptive title
-                        title = f"{bill_ref}: {title_raw}"
-                        if len(title) > 250:
-                            title = title[:247] + "..."
-                        
-                        # Target URL exactly as requested:
-                        link = f"https://www.congreso.es/es/busqueda-de-iniciativas?p_p_id=iniciativas&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_iniciativas_mode=mostrarDetalle&_iniciativas_legislatura={legislatura}&_iniciativas_id={bill_ref}"
-                        
-                        # Using "Documentation" label as requested
-                        desc = f"{title_raw}\n\nAutor: {autor_str}\nFecha: {date_str}\nDocumentation: {link}"
-                        output[title] = desc
-                except Exception:
-                    continue
-    except Exception:
-        pass
 
-print(json.dumps(output, ensure_ascii=False))
+    for src in SOURCES:
+        ajax_url = src["url"] + AJAX_SUFFIX
+        payload = {
+            "_iniciativas_legislatura": "15",
+            "_iniciativas_estadoTramitacion": "",
+            "_iniciativas_faseTramitacion": "",
+            "_iniciativas_cini": src["cini"],
+            "_iniciativas_tipoLlamada": "T",
+            "_iniciativas_paginaActual": "1",
+        }
+        try:
+            response = requests.post(
+                ajax_url,
+                data=payload,
+                headers=header,
+                timeout=REQUEST_TIMEOUT,
+                verify=False,
+            )
+        except requests.RequestException:
+            continue
+
+        if response.status_code != 200:
+            continue
+
+        try:
+            data = response.json()
+        except ValueError:
+            continue
+
+        initiatives = data.get("lista_iniciativas", {})
+        if not isinstance(initiatives, dict):
+            continue
+
+        for _key, item in initiatives.items():
+            if not isinstance(item, dict):
+                continue
+            date_str = item.get("fecha_presentado", "")
+            if not date_str:
+                continue
+            try:
+                item_date = datetime.datetime.strptime(date_str, "%d/%m/%Y")
+            except ValueError:
+                continue
+            if item_date < cutoff:
+                continue
+
+            title_raw = (item.get("titulo") or "").strip()
+            if not title_raw:
+                continue
+
+            bill_ref = item.get("id_iniciativa", "")
+            legislatura = item.get("legislatura", "XV")
+            autor_str = _collect_authors(item.get("autores", {}))
+
+            title = f"{bill_ref}: {title_raw}"
+            if len(title) > MAX_TITLE_LEN:
+                title = title[: MAX_TITLE_LEN - 3] + "..."
+
+            link = (
+                "https://www.congreso.es/es/busqueda-de-iniciativas?"
+                "p_p_id=iniciativas&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&"
+                "_iniciativas_mode=mostrarDetalle&"
+                f"_iniciativas_legislatura={legislatura}&_iniciativas_id={bill_ref}"
+            )
+            desc = (
+                f"{title_raw}\n\nAutor: {autor_str}\nFecha: {date_str}\n"
+                f"Documentation: {link}"
+            )
+            output[title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_congreso_iniciativas(), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_FR.py
+++ b/python/scrape_FR.py
@@ -1,67 +1,84 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape recent French National Assembly parliamentary documents from RSS.
+
+Filters items to roughly the last 90 days by pubDate and prints a JSON object
+mapping truncated title to a short description with source link.
+
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
+import datetime
 import json
+
 import requests
 import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import datetime
-import ssl
 from bs4 import BeautifulSoup
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+RSS_URL = "http://www2.assemblee-nationale.fr/feeds/detail/documents-parlementaires"
+REQUEST_TIMEOUT = 15
+RECENT_DAYS = 90
+MAX_TITLE_LEN = 250
 
-output = {}
 
-today = datetime.datetime.now()
-three_months_ago = today - datetime.timedelta(days=90)
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-# Assemblée Nationale RSS feed for parliamentary documents
-url = "http://www2.assemblee-nationale.fr/feeds/detail/documents-parlementaires"
 
-header = {
-    "User-Agent": "Mozilla/5.0"
-}
+def scrape_assemblee_documents() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    today = datetime.datetime.now()
+    cutoff = today - datetime.timedelta(days=RECENT_DAYS)
+    output: dict[str, str] = {}
 
-try:
-    response = requests.get(url, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
-        # Use BeautifulSoup to parse the XML
-        soup = BeautifulSoup(response.content, features="xml")
-        items = soup.find_all("item")
-        
-        for item in items:
-            pub_date_str = item.find("pubDate").text if item.find("pubDate") else ""
-            if not pub_date_str:
-                continue
-                
-            try:
-                # Format: Tue, 03 Mar 2026 00:00:00 +0000
-                # We only need the date part
-                date_clean = " ".join(pub_date_str.split()[1:4])
-                item_date = datetime.datetime.strptime(date_clean, "%d %b %Y")
-                
-                if item_date >= three_months_ago:
-                    title_raw = item.find("title").text if item.find("title") else ""
-                    if not title_raw:
-                        continue
-                    
-                    # France format is often: "N° 2548 - Proposition de loi de M. ..."
-                    # We can use the whole title as it is quite descriptive
-                    title = title_raw.strip()
-                    
-                    # Truncate if too long
-                    if len(title) > 250:
-                        title = title[:247] + "..."
-                    
-                    link = item.find("link").text if item.find("link") else ""
-                    desc = f"{title}\nSource: {link}"
-                    
-                    output[title] = desc
-            except Exception:
-                continue
-except Exception:
-    pass
+    try:
+        response = requests.get(
+            RSS_URL,
+            headers={"User-Agent": "Mozilla/5.0"},
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+    except requests.RequestException:
+        return output
 
-print(json.dumps(output))
+    if response.status_code != 200:
+        return output
+
+    soup = BeautifulSoup(response.content, features="xml")
+    for item in soup.find_all("item"):
+        pub_el = item.find("pubDate")
+        if not pub_el or not pub_el.text:
+            continue
+        pub_date_str = pub_el.text
+        try:
+            date_clean = " ".join(pub_date_str.split()[1:4])
+            item_date = datetime.datetime.strptime(date_clean, "%d %b %Y")
+        except (ValueError, IndexError):
+            continue
+
+        if item_date < cutoff:
+            continue
+
+        title_el = item.find("title")
+        if not title_el or not title_el.text:
+            continue
+        title = title_el.text.strip()
+        if len(title) > MAX_TITLE_LEN:
+            title = title[: MAX_TITLE_LEN - 3] + "..."
+
+        link_el = item.find("link")
+        link = link_el.text.strip() if link_el and link_el.text else ""
+        desc = f"{title}\nSource: {link}"
+        output[title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_assemblee_documents()))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_GB.py
+++ b/python/scrape_GB.py
@@ -1,37 +1,53 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape UK Parliament bills from the official \"all bills\" RSS feed.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Prints a flat list: title, description, title, description, ... for each item.
 
-from bs4 import BeautifulSoup
-import ssl
-import sys
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import requests
 import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-#import numpy as np
+from bs4 import BeautifulSoup
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+RSS_URL = "https://bills.parliament.uk/rss/allbills.rss"
+REQUEST_TIMEOUT = 30
 
-output = []
 
-# URl needs to be dynamic
-url = 'https://bills.parliament.uk/rss/allbills.rss'
-xml = requests.get(url, verify=False)
-soup = BeautifulSoup(xml.content, features='xml')
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-items = soup.find_all("item")
-for item in items:
-    title = item.find("title").getText()
-    link = item.find("link").getText()
-    desc = item.find("description").getText().strip()
-    output.append(title)
-    output.append(desc) 
 
-print(output)
+def fetch_bills_rss() -> list[str]:
+    """Return flattened title/description pairs from the RSS feed."""
+    _disable_insecure_request_warnings()
+    response = requests.get(RSS_URL, timeout=REQUEST_TIMEOUT, verify=False)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.content, features="xml")
+    output: list[str] = []
+
+    for item in soup.find_all("item"):
+        title_el = item.find("title")
+        link_el = item.find("link")
+        desc_el = item.find("description")
+        if not title_el or not desc_el:
+            continue
+        title = title_el.getText()
+        desc = desc_el.getText().strip()
+        output.append(title)
+        output.append(desc)
+        # Original also read link but only appended title and description.
+
+    return output
+
+
+def main() -> None:
+    print(fetch_bills_rss())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_ID.py
+++ b/python/scrape_ID.py
@@ -1,92 +1,83 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape Indonesian DPR bill detail pages by numeric id.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Walks /uu/detail/id/{n}, collects up to 20 titles, and prints JSON. Stops after
+too many consecutive failures (including non-200 responses).
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
-import sys
-import requests
-import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import re
-#import numpy as np
+Dependencies: beautifulsoup4, lxml (parser), requests, urllib3
+"""
+
+from __future__ import annotations
 
 import json
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+import requests
+import urllib3
+from bs4 import BeautifulSoup
 
-output = {}
+DETAIL_URL_TEMPLATE = "https://www.dpr.go.id/uu/detail/id/{id}"
+START_ID = 1300
+MAX_ITEMS = 20
+MAX_CONSECUTIVE_FAILURES = 10
+REQUEST_TIMEOUT = 10
 
-header = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-}
 
-# URl needs to be dynamic
-import datetime
-today = datetime.datetime.now()
-stop = False
-# start = 238  # Original start ID
-start = 1300 # Try a more recent ID range for 2024-2026
-errorcount = 0
-max_errors = 10
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-while not stop and len(output) < 20: # Limit to 20 per run
-    url = 'https://www.dpr.go.id/uu/detail/id/'+str(start)
-    try:
-        response = requests.get(url, headers=header, timeout=10, verify=False)
-        if response.status_code == 200:
-            soup = BeautifulSoup(response.text, features="lxml")
-            h3 = soup.find("h3")
-            if h3:
-                title = h3.getText().strip()
-                if title:
-                    desc = "Source: " + url
-                    output[title] = desc
-                    errorcount = 0 # reset error count on success
-            else:
-                errorcount += 1
-        elif response.status_code == 403:
-            # If we get 403, we might be blocked, but let's try a few more IDs
-            errorcount += 1
+
+def scrape_dpr_bills() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+        )
+    }
+
+    bill_id = START_ID
+    consecutive_failures = 0
+    stop = False
+
+    while not stop and len(output) < MAX_ITEMS:
+        url = DETAIL_URL_TEMPLATE.format(id=bill_id)
+        try:
+            response = requests.get(
+                url,
+                headers=headers,
+                timeout=REQUEST_TIMEOUT,
+                verify=False,
+            )
+        except requests.RequestException:
+            consecutive_failures += 1
         else:
-            errorcount += 1
-            
-    except Exception as e:
-        errorcount += 1
-    
-    if errorcount >= max_errors:
-        stop = True
-    
-    start += 1
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.text, features="lxml")
+                h3 = soup.find("h3")
+                if h3:
+                    title = h3.getText().strip()
+                    if title:
+                        output[title] = "Source: " + url
+                        consecutive_failures = 0
+                    else:
+                        consecutive_failures += 1
+                else:
+                    consecutive_failures += 1
+            else:
+                consecutive_failures += 1
 
-print(json.dumps(output))
+        if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+            stop = True
+        bill_id += 1
 
-#print(topicno)
-#print(status)
-#print(url)
-#print(uzeit) 
-#list_of_contents.remove("\n")
-#list_of_contents.remove(" ")
+    return output
 
 
-#print(list_of_contents)
+def main() -> None:
+    print(json.dumps(scrape_dpr_bills()))
 
-#print(topiclist)
 
-#f = open('BT_Tagesordnung.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in output))
-#f.close
-
-#f = open('BT_Tagesordnung.txt', 'a')
-#f.write("\n".join(str(item) for item in url))
-#f.close
+if __name__ == "__main__":
+    main()

--- a/python/scrape_IE.py
+++ b/python/scrape_IE.py
@@ -1,91 +1,92 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape Irish Oireachtas bill pages for the current calendar year.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Walks /en/bills/bill/{year}/{n}/ until consecutive HTTP failures, and prints
+a flat list of title and description (long title plus bill URL).
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
-import sys
-#import numpy as np
+Dependencies: beautifulsoup4
+"""
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+from __future__ import annotations
 
-output = []
-
-# URl needs to be dynamic
 import datetime
-today = datetime.datetime.now()
-year = today.year
-stop = False
-start = 1
-errorcount = 0
-while not stop:
-    url = 'https://www.oireachtas.ie/en/bills/bill/'+str(year)+'/'+str(start)+'/'
-    try:
-        html = urllib.request.urlopen(url, context=ctx).read()
-    except urllib.error.HTTPError as e:
-        if e:
-            errorcount += 1
-            start += 1
-            if errorcount == 5:
+import ssl
+import urllib.error
+import urllib.request
+from bs4 import BeautifulSoup
+
+MAX_CONSECUTIVE_FAILURES = 5
+BILL_URL_TEMPLATE = "https://www.oireachtas.ie/en/bills/bill/{year}/{num}/"
+
+
+def create_unverified_ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def scrape_oireachtas_bills() -> list[str]:
+    ctx = create_unverified_ssl_context()
+    year = datetime.date.today().year
+    output: list[str] = []
+    bill_num = 1
+    consecutive_failures = 0
+    stop = False
+
+    while not stop:
+        url = BILL_URL_TEMPLATE.format(year=year, num=bill_num)
+        try:
+            with urllib.request.urlopen(url, context=ctx) as response:
+                html = response.read()
+        except urllib.error.HTTPError:
+            consecutive_failures += 1
+            bill_num += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
                 stop = True
             continue
-    soup = BeautifulSoup(html, 'html.parser')
 
-    title = ""
-    desc = ""
+        soup = BeautifulSoup(html, "html.parser")
+        hero = soup.find("div", {"class": "c-hero__content"})
+        if not hero:
+            consecutive_failures += 1
+            bill_num += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                stop = True
+            continue
 
-    title = soup.find("div", {'class': 'c-hero__content'}).getText().strip()
-    if not title:
-        errorcount += 1
-        start += 1
-        if errorcount == 5:
-            stop = True
-        continue
-    title = title.replace("'", "&#39;")
-    title = title.replace("\n", " ")
-    desc = soup.find("p", {'class': 'c-bill-intro__long-title'})
-    #if not desc:
-    #    desc = soup.find("p", {'class': 'NormalInd'})
-        
-    desc = desc.getText().strip()
-    desc = desc.replace("'", "&#39;")
-    href = url
-    desc = desc + "\n" + href
+        title = hero.getText().strip()
+        if not title:
+            consecutive_failures += 1
+            bill_num += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                stop = True
+            continue
 
-    output.append(title)
-    output.append(desc) 
-    #print(start)   
+        title = title.replace("'", "&#39;").replace("\n", " ")
 
-    start = start + 1
+        desc_el = soup.find("p", {"class": "c-bill-intro__long-title"})
+        if not desc_el:
+            consecutive_failures += 1
+            bill_num += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                stop = True
+            continue
 
-print(output)
+        desc = desc_el.getText().strip().replace("'", "&#39;")
+        desc = desc + "\n" + url
 
-#print(topicno)
-#print(status)
-#print(url)
-#print(uzeit) 
-#list_of_contents.remove("\n")
-#list_of_contents.remove(" ")
+        output.append(title)
+        output.append(desc)
+        bill_num += 1
+
+    return output
 
 
-#print(list_of_contents)
+def main() -> None:
+    print(scrape_oireachtas_bills())
 
-#print(topiclist)
 
-#f = open('BT_Tagesordnung.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in output))
-#f.close
-
-#f = open('BT_Tagesordnung.txt', 'a')
-#f.write("\n".join(str(item) for item in url))
-#f.close
+if __name__ == "__main__":
+    main()

--- a/python/scrape_IN.py
+++ b/python/scrape_IN.py
@@ -1,92 +1,135 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape recent Indian bill detail pages from PRS Legislative Research.
+
+Loads the billtrack index, follows the first few bill links, extracts PDF and
+status metadata, and prints JSON (UTF-8 preserved).
+
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import json
-import requests
-from bs4 import BeautifulSoup
-import warnings
-import urllib3
-import datetime
 import re
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+import requests
+import urllib3
+from bs4 import BeautifulSoup
 
-output = {}
-base_url = "https://prsindia.org"
-list_url = f"{base_url}/billtrack"
+BASE_URL = "https://prsindia.org"
+LIST_URL = f"{BASE_URL}/billtrack"
+REQUEST_TIMEOUT = 15
+MAX_BILLS = 10
+MAX_TITLE_LEN = 250
 
-header = {
-    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
-}
 
-try:
-    response = requests.get(list_url, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
-        soup = BeautifulSoup(response.text, 'html.parser')
-        
-        # Find all bill entries
-        # They usually have titles in h3 > a
-        bill_items = []
-        for h3 in soup.find_all("h3"):
-            a = h3.find("a", href=True)
-            if a and "/billtrack/" in a['href']:
-                href = a['href']
-                if any(x in href for x in ["/category/", "/field_bill_category/", "/search", "/overview-"]):
-                    continue
-                
-                title = a.get_text().strip()
-                full_url = base_url + href if href.startswith("/") else href
-                bill_items.append({"title": title, "url": full_url})
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-        # Process the 10 most recent bills
-        for item in bill_items[:10]:
-            try:
-                bill_url = item["url"]
-                title = item["title"]
-                
-                det_resp = requests.get(bill_url, headers=header, timeout=10, verify=False)
-                if det_resp.status_code == 200:
-                    det_soup = BeautifulSoup(det_resp.text, 'html.parser')
-                    
-                    pdf_link = ""
-                    # PRS detail pages have links to PDF files
-                    # Look for links that contain "Bill Text" or "Introduced"
-                    pdf_tags = det_soup.find_all("a", href=re.compile(r"\.pdf$", re.I))
-                    for pt in pdf_tags:
-                        pt_text = pt.get_text().lower()
-                        if "bill text" in pt_text or "introduced" in pt_text or "text of the bill" in pt_text:
-                            pdf_link = pt.get("href")
-                            break
-                    
-                    if not pdf_link and pdf_tags:
-                        pdf_link = pdf_tags[0].get("href")
-                    
-                    if pdf_link:
-                        if pdf_link.startswith("../"):
-                            # Handle PRS relative path ../files/...
-                            pdf_link = base_url + "/" + pdf_link.replace("../", "")
-                        elif pdf_link.startswith("/"):
-                            pdf_link = base_url + pdf_link
 
-                    # Metadata: Status
-                    status = "N/A"
-                    status_div = det_soup.find("div", class_="field-bill-status")
-                    if status_div:
-                        status = status_div.get_text().replace("Status:", "").strip()
-                    
-                    if len(title) > 250:
-                        title = title[:247] + "..."
-                    
-                    desc = f"{title}\n\n"
-                    desc += f"Status: {status}\n"
-                    if pdf_link:
-                        desc += f"Official Bill Text (PDF): {pdf_link}\n"
-                    desc += f"Source: {bill_url}"
-                    
-                    output[title] = desc
-            except:
-                continue
+def scrape_prs_bills() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
+    }
 
-except Exception:
-    pass
+    try:
+        response = requests.get(
+            LIST_URL,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+    except requests.RequestException:
+        return output
 
-print(json.dumps(output, ensure_ascii=False))
+    if response.status_code != 200:
+        return output
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    bill_items: list[dict[str, str]] = []
+
+    for h3 in soup.find_all("h3"):
+        anchor = h3.find("a", href=True)
+        if not anchor or "/billtrack/" not in anchor["href"]:
+            continue
+        href = anchor["href"]
+        if any(
+            x in href
+            for x in (
+                "/category/",
+                "/field_bill_category/",
+                "/search",
+                "/overview-",
+            )
+        ):
+            continue
+        title = anchor.get_text().strip()
+        full_url = BASE_URL + href if href.startswith("/") else href
+        bill_items.append({"title": title, "url": full_url})
+
+    for item in bill_items[:MAX_BILLS]:
+        try:
+            detail = requests.get(
+                item["url"],
+                headers=headers,
+                timeout=10,
+                verify=False,
+            )
+        except requests.RequestException:
+            continue
+
+        if detail.status_code != 200:
+            continue
+
+        det_soup = BeautifulSoup(detail.text, "html.parser")
+        pdf_link = ""
+        pdf_tags = det_soup.find_all("a", href=re.compile(r"\.pdf$", re.I))
+        for pt in pdf_tags:
+            pt_text = pt.get_text().lower()
+            if (
+                "bill text" in pt_text
+                or "introduced" in pt_text
+                or "text of the bill" in pt_text
+            ):
+                pdf_link = pt.get("href") or ""
+                break
+        if not pdf_link and pdf_tags:
+            pdf_link = pdf_tags[0].get("href") or ""
+
+        if pdf_link.startswith("../"):
+            pdf_link = BASE_URL + "/" + pdf_link.replace("../", "")
+        elif pdf_link.startswith("/"):
+            pdf_link = BASE_URL + pdf_link
+
+        status = "N/A"
+        status_div = det_soup.find("div", class_="field-bill-status")
+        if status_div:
+            status = status_div.get_text().replace("Status:", "").strip()
+
+        title = item["title"]
+        if len(title) > MAX_TITLE_LEN:
+            title = title[: MAX_TITLE_LEN - 3] + "..."
+
+        desc = f"{title}\n\n"
+        desc += f"Status: {status}\n"
+        if pdf_link:
+            desc += f"Official Bill Text (PDF): {pdf_link}\n"
+        desc += f"Source: {item['url']}"
+
+        output[title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_prs_bills(), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_IT.py
+++ b/python/scrape_IT.py
@@ -1,68 +1,84 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape Italian Chamber of Deputies bill list HTML for titles and detail links.
+
+Parses law sections from the published index page and prints JSON mapping title
+to description including an absolute source URL when available.
+
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import json
+
 import requests
 import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import datetime
-import ssl
 from bs4 import BeautifulSoup
-import warnings
 
-# Ignore SSL certificate warnings
-warnings.filterwarnings("ignore", category=requests.packages.urllib3.exceptions.InsecureRequestWarning)
+LIST_URL = "https://www.parlamento.it/leg/ldl_new/v3/sldlelencodlconvers.htm"
+SITE_ORIGIN = "https://www.parlamento.it"
+REQUEST_TIMEOUT = 15
+MAX_TITLE_LEN = 250
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
 
-output = {}
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-# URL from the original IT scraper
-url = 'https://www.parlamento.it/leg/ldl_new/v3/sldlelencodlconvers.htm'
 
-header = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-}
+def scrape_camera_bills() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+        )
+    }
 
-try:
-    response = requests.get(url, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
-        # Use explicit encoding if needed, but requests usually handles it
-        soup = BeautifulSoup(response.content, 'html.parser')
+    try:
+        response = requests.get(
+            LIST_URL,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+        if response.status_code != 200:
+            return output
+        soup = BeautifulSoup(response.content, "html.parser")
+        for section in soup.find_all("dl", {"class": "leggi"}):
+            titles = section.find_all("p", {"class": "titoloLegge"})
+            links = section.find_all("dt")
 
-        # Logic from the original scraper
-        laws_sections = soup.findAll("dl", {'class': 'leggi'})
-        for section in laws_sections:
-            titles = section.findAll("p", {'class': 'titoloLegge'})
-            links = section.findAll("dt")
-                 
-            for idx, t in enumerate(titles):
-                title = t.getText().strip() 
-                # Remove leading/trailing quotes often found in Italian law titles
-                title = title.strip('"')
-                
-                # Truncate if too long for DB (usually 255 chars)
-                if len(title) > 250:
-                    title = title[:247] + "..."
-                
-                # Get link
+            for idx, title_el in enumerate(titles):
+                title = title_el.getText().strip().strip('"')
+                if len(title) > MAX_TITLE_LEN:
+                    title = title[: MAX_TITLE_LEN - 3] + "..."
+
                 href = ""
                 if idx < len(links):
-                    a_tag = links[idx].find('a')
+                    a_tag = links[idx].find("a")
                     if a_tag:
-                        href = a_tag.get('href', '')
-                
-                if href and not href.startswith('http'):
-                    href = 'https://www.parlamento.it' + href
-                
+                        href = a_tag.get("href", "") or ""
+
+                if href and not href.startswith("http"):
+                    href = SITE_ORIGIN + href
+
                 desc = title
                 if href:
                     desc = f"{title}\nSource: {href}"
-                
+
                 if title:
                     output[title] = desc
-except Exception:
-    pass
+    except requests.RequestException:
+        pass
 
-print(json.dumps(output))
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_camera_bills()))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_JM.py
+++ b/python/scrape_JM.py
@@ -1,68 +1,62 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape Jamaica Parliament public bills listing.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Fetches the bills page, iterates list items under the article body, and prints
+a flat list of title text and description (text plus document URL).
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
+Dependencies: beautifulsoup4
+"""
+
+from __future__ import annotations
+
 import ssl
-import sys
-#import numpy as np
+import urllib.request
+from bs4 import BeautifulSoup
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
-
-output = []
-
-# URl needs to be dynamic
-import datetime
-today = datetime.datetime.now()
-year = today.year
-errorcount = 0
-baseurl = 'https://www.japarliament.gov.jm'
-url = 'https://www.japarliament.gov.jm/index.php/publications/bills/public-bills'
-html = urllib.request.urlopen(url, context=ctx).read()
-soup = BeautifulSoup(html, 'html.parser')
-section = soup.find("div", {'itemprop': 'articleBody'})
-topics = section.findAll("li")
-for item in topics:
-    title = ""
-    desc = ""
-    title = item.getText().strip()
-    title = title.replace("\n", " ")
-    desc = item.getText().strip()
-    href = baseurl + item.find('a').get('href')
-    href = href.replace(" ", "%20")
-    desc = desc + "\n" + href
-
-    output.append(title)
-    output.append(desc) 
-
-print(output)
-
-#print(topicno)
-#print(status)
-#print(url)
-#print(uzeit) 
-#list_of_contents.remove("\n")
-#list_of_contents.remove(" ")
+BASE_URL = "https://www.japarliament.gov.jm"
+LIST_URL = f"{BASE_URL}/index.php/publications/bills/public-bills"
 
 
-#print(list_of_contents)
+def create_unverified_ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
 
-#print(topiclist)
 
-#f = open('BT_Tagesordnung.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in output))
-#f.close
+def scrape_jm_public_bills() -> list[str]:
+    ctx = create_unverified_ssl_context()
+    with urllib.request.urlopen(LIST_URL, context=ctx) as response:
+        html = response.read()
 
-#f = open('BT_Tagesordnung.txt', 'a')
-#f.write("\n".join(str(item) for item in url))
-#f.close
+    soup = BeautifulSoup(html, "html.parser")
+    section = soup.find("div", {"itemprop": "articleBody"})
+    if not section:
+        return []
+
+    output: list[str] = []
+    for item in section.find_all("li"):
+        title = item.getText().strip().replace("\n", " ")
+        desc = item.getText().strip()
+        link = item.find("a")
+        if not link:
+            continue
+        href = link.get("href")
+        if not href:
+            continue
+        href = BASE_URL + href
+        href = href.replace(" ", "%20")
+        desc = desc + "\n" + href
+        output.append(title)
+        output.append(desc)
+
+    return output
+
+
+def main() -> None:
+    print(scrape_jm_public_bills())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_JP.py
+++ b/python/scrape_JP.py
@@ -1,79 +1,104 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape Japanese House of Representatives (Shugiin) bill tables for a session.
+
+Decodes Shift_JIS HTML, walks table rows, and prints JSON keyed by a short display
+title with category, session, status, and source link.
+
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import json
+
 import requests
-from bs4 import BeautifulSoup
-import warnings
 import urllib3
+from bs4 import BeautifulSoup
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+SESSION_URL = "https://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/kaiji217.htm"
+BASE_URL = "https://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/"
+REQUEST_TIMEOUT = 15
 
-output = {}
-# Current session 217 URL
-url = "https://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/kaiji217.htm"
-base_url = "https://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/"
 
-header = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
-}
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-try:
-    response = requests.get(url, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
-        # Site uses Shift_JIS
-        content = response.content.decode('shift_jis', errors='replace')
-        soup = BeautifulSoup(content, 'html.parser')
-        
-        # Tables with bills
-        tables = soup.find_all("table", class_="table")
-        
-        for table in tables:
-            caption = table.find("caption")
-            category_type = caption.get_text().strip() if caption else "議案"
-            
-            rows = table.find_all("tr")
-            for row in rows:
-                cols = row.find_all("td")
-                if len(cols) >= 3:
-                    # Column indices: 0: Session, 1: Number, 2: Title, 3: Status, 4: History, 5: Text
-                    session_num = cols[0].get_text().strip()
-                    bill_num = cols[1].get_text().strip()
-                    title_raw = cols[2].get_text().strip()
-                    status = cols[3].get_text().strip() if len(cols) > 3 else ""
-                    
-                    # Full title for DB - very aggressive truncation for Japanese UTF-8 safety (3 bytes per char)
-                    # 70 chars * 3 = 210 bytes, safely under 255
-                    display_title = f"[{category_type}] {title_raw} ({bill_num})"
-                    
-                    if len(display_title) > 70:
-                        display_title = display_title[:67] + "..."
-                    
-                    # Link to history (keika)
-                    link_tag = cols[4].find("a") if len(cols) > 4 else None
-                    if not link_tag and len(cols) > 5: # check text link
-                        link_tag = cols[5].find("a")
-                        
-                    source_link = url
-                    if link_tag:
-                        href = link_tag.get("href")
-                        if href:
-                            if href.startswith("."):
-                                source_link = base_url + href[2:]
-                            elif not href.startswith("http"):
-                                source_link = base_url + href
-                            else:
-                                source_link = href
-                    
-                    desc = f"{title_raw}\n\n"
-                    desc += f"Category: {category_type}\n"
-                    desc += f"Session: {session_num}\n"
-                    desc += f"Number: {bill_num}\n"
-                    desc += f"Status: {status}\n"
-                    desc += f"Source: {source_link}"
-                    
-                    output[display_title] = desc
 
-except Exception:
-    pass
+def scrape_shugiin_gian() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
+    }
 
-print(json.dumps(output, ensure_ascii=False))
+    try:
+        response = requests.get(
+            SESSION_URL,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+    except requests.RequestException:
+        return output
+
+    if response.status_code != 200:
+        return output
+
+    content = response.content.decode("shift_jis", errors="replace")
+    soup = BeautifulSoup(content, "html.parser")
+
+    for table in soup.find_all("table", class_="table"):
+        caption = table.find("caption")
+        category_type = caption.get_text().strip() if caption else "議案"
+
+        for row in table.find_all("tr"):
+            cols = row.find_all("td")
+            if len(cols) < 3:
+                continue
+
+            session_num = cols[0].get_text().strip()
+            bill_num = cols[1].get_text().strip()
+            title_raw = cols[2].get_text().strip()
+            status = cols[3].get_text().strip() if len(cols) > 3 else ""
+
+            display_title = f"[{category_type}] {title_raw} ({bill_num})"
+            if len(display_title) > 70:
+                display_title = display_title[:67] + "..."
+
+            link_tag = cols[4].find("a") if len(cols) > 4 else None
+            if not link_tag and len(cols) > 5:
+                link_tag = cols[5].find("a")
+
+            source_link = SESSION_URL
+            if link_tag:
+                href = link_tag.get("href")
+                if href:
+                    if href.startswith("."):
+                        source_link = BASE_URL + href[2:]
+                    elif not href.startswith("http"):
+                        source_link = BASE_URL + href
+                    else:
+                        source_link = href
+
+            desc = f"{title_raw}\n\n"
+            desc += f"Category: {category_type}\n"
+            desc += f"Session: {session_num}\n"
+            desc += f"Number: {bill_num}\n"
+            desc += f"Status: {status}\n"
+            desc += f"Source: {source_link}"
+
+            output[display_title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_shugiin_gian(), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_KR.py
+++ b/python/scrape_KR.py
@@ -1,64 +1,86 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape South Korea-related legislative news via Google News RSS.
+
+Keyword-filters Korean headlines and prints JSON (UTF-8 preserved).
+
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import json
+
 import requests
-import datetime
-import ssl
-from bs4 import BeautifulSoup
-import warnings
 import urllib3
-import re
+from bs4 import BeautifulSoup
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+RSS_URL = (
+    "https://news.google.com/rss/search?q="
+    "%EA%B5%AD%ED%9A%8C+%EB%B0%9C%EC%9D%98+%EB%B2%95%EC%95%88"
+    "&hl=ko&gl=KR&ceid=KR:ko"
+)
+REQUEST_TIMEOUT = 15
+MAX_TITLE_LEN = 250
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+KEYWORDS = ["국회", "발의", "법안", "개정안", "제정안", "의안"]
 
-output = {}
 
-# Google News RSS workaround for South Korean legislative initiatives
-# Querying for "국회 발의 법안" (National Assembly proposed bills)
-url = "https://news.google.com/rss/search?q=%EA%B5%AD%ED%9A%8C+%EB%B0%9C%EC%9D%98+%EB%B2%95%EC%95%88&hl=ko&gl=KR&ceid=KR:ko"
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-header = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
-}
 
-# Keywords to ensure we get legislation-related news
-# 국회 (National Assembly), 발의 (propose), 법안 (bill), 개정안 (amendment)
-keywords = ["국회", "발의", "법안", "개정안", "제정안", "의안"]
+def scrape_kr_news() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
+    }
 
-try:
-    response = requests.get(url, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
-        soup = BeautifulSoup(response.content, features="xml")
-        items = soup.find_all("item")
-        
-        for item in items:
-            title_raw = item.find("title").text if item.find("title") else ""
-            link = item.find("link").text if item.find("link") else ""
-            pub_date = item.find("pubDate").text if item.find("pubDate") else ""
-            
-            title = title_raw.strip()
-            
-            # Filter for relevance
-            is_relevant = any(kw in title for kw in keywords)
-            
-            if is_relevant:
-                # Clean up title (remove source name at the end)
-                if " - " in title:
-                    title = title.rsplit(" - ", 1)[0]
-                
-                if len(title) > 250:
-                    title = title[:247] + "..."
-                
-                desc = f"{title}\n날짜: {pub_date}\nSource: {link}"
-                
-                output[title] = desc
+    try:
+        response = requests.get(
+            RSS_URL,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+    except requests.RequestException:
+        return output
 
-except Exception:
-    pass
+    if response.status_code != 200:
+        return output
 
-print(json.dumps(output, ensure_ascii=False))
+    soup = BeautifulSoup(response.content, features="xml")
+    for item in soup.find_all("item"):
+        title_el = item.find("title")
+        link_el = item.find("link")
+        pub_el = item.find("pubDate")
+        if not title_el or not link_el:
+            continue
+
+        title = (title_el.text or "").strip()
+        if not any(kw in title for kw in KEYWORDS):
+            continue
+
+        if " - " in title:
+            title = title.rsplit(" - ", 1)[0]
+        if len(title) > MAX_TITLE_LEN:
+            title = title[: MAX_TITLE_LEN - 3] + "..."
+
+        link = link_el.text or ""
+        pub_date = pub_el.text if pub_el and pub_el.text else ""
+        desc = f"{title}\n날짜: {pub_date}\nSource: {link}"
+        output[title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_kr_news(), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_MX.py
+++ b/python/scrape_MX.py
@@ -1,80 +1,117 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape Mexico-related legislative news via Google News RSS (primary + fallback).
+
+Keyword-filters items for relevance, normalizes titles, and prints JSON
+(UTF-8 preserved).
+
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import json
+
 import requests
-import datetime
-import ssl
-from bs4 import BeautifulSoup
-import warnings
 import urllib3
+from bs4 import BeautifulSoup
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+PRIMARY_RSS = (
+    "https://news.google.com/rss/search?q=iniciativas+ley+mexico+congreso+gaceta"
+    "&hl=es-419&gl=MX&ceid=MX:es-419"
+)
+FALLBACK_RSS = (
+    "https://news.google.com/rss/search?q=gaceta+parlamentaria+mexico+iniciativas"
+    "&hl=es-419&gl=MX&ceid=MX:es-419"
+)
+REQUEST_TIMEOUT = 15
+MAX_TITLE_LEN = 250
 
-# Ignore SSL certificate warnings
-warnings.filterwarnings("ignore", category=requests.packages.urllib3.exceptions.InsecureRequestWarning)
+KEYWORDS = [
+    "iniciativa",
+    "ley",
+    "congreso",
+    "senado",
+    "diputados",
+    "gaceta",
+    "reforma",
+    "decreto",
+]
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
 
-output = {}
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-# Google News RSS workaround for Mexican legislative initiatives
-# Searching specifically for initiatives in the Mexican Congress
-url = "https://news.google.com/rss/search?q=iniciativas+ley+mexico+congreso+gaceta&hl=es-419&gl=MX&ceid=MX:es-419"
 
-header = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
-}
+def _normalize_google_title(raw: str) -> str:
+    title = raw.strip()
+    if " - " in title:
+        title = title.rsplit(" - ", 1)[0]
+    if len(title) > MAX_TITLE_LEN:
+        title = title[: MAX_TITLE_LEN - 3] + "..."
+    return title
 
-keywords = ["iniciativa", "ley", "congreso", "senado", "diputados", "gaceta", "reforma", "decreto"]
 
-try:
-    response = requests.get(url, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
-        soup = BeautifulSoup(response.content, features="xml")
-        items = soup.find_all("item")
-        
-        for item in items:
-            title_raw = item.find("title").text if item.find("title") else ""
-            link = item.find("link").text if item.find("link") else ""
-            pub_date = item.find("pubDate").text if item.find("pubDate") else ""
-            
-            title = title_raw.strip()
-            
-            # Filter for relevance to ensure we get legislation-related news
-            is_relevant = any(kw in title.lower() for kw in keywords)
-            
-            if is_relevant:
-                # Clean up title (remove source name at the end usually "- Source")
-                if " - " in title:
-                    title = title.rsplit(" - ", 1)[0]
-                
-                if len(title) > 250:
-                    title = title[:247] + "..."
-                
-                desc = f"{title}\nFecha: {pub_date}\nSource: {link}"
-                
-                output[title] = desc
+def _fetch_rss_items(url: str, headers: dict[str, str]) -> list:
+    response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT, verify=False)
+    if response.status_code != 200:
+        return []
+    soup = BeautifulSoup(response.content, features="xml")
+    return soup.find_all("item")
 
-except Exception:
-    pass
 
-# If Google News failed or returned nothing, we try a more generic search
-if not output:
+def scrape_mx_news() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
+    }
+
     try:
-        url_alt = "https://news.google.com/rss/search?q=gaceta+parlamentaria+mexico+iniciativas&hl=es-419&gl=MX&ceid=MX:es-419"
-        response = requests.get(url_alt, headers=header, timeout=15, verify=False)
-        if response.status_code == 200:
-            soup = BeautifulSoup(response.content, features="xml")
-            items = soup.find_all("item")
-            for item in items:
-                title = item.find("title").text if item.find("title") else ""
-                link = item.find("link").text if item.find("link") else ""
-                if " - " in title: title = title.rsplit(" - ", 1)[0]
-                if len(title) > 250: title = title[:247] + "..."
-                output[title] = f"{title}\nSource: {link}"
-    except:
+        for item in _fetch_rss_items(PRIMARY_RSS, headers):
+            title_el = item.find("title")
+            link_el = item.find("link")
+            pub_el = item.find("pubDate")
+            if not title_el or not link_el:
+                continue
+            title_raw = title_el.text or ""
+            link = link_el.text or ""
+            pub_date = pub_el.text if pub_el and pub_el.text else ""
+
+            title = title_raw.strip()
+            if not any(kw in title.lower() for kw in KEYWORDS):
+                continue
+
+            title = _normalize_google_title(title)
+            desc = f"{title}\nFecha: {pub_date}\nSource: {link}"
+            output[title] = desc
+    except requests.RequestException:
         pass
 
-print(json.dumps(output, ensure_ascii=False))
+    if output:
+        return output
+
+    try:
+        for item in _fetch_rss_items(FALLBACK_RSS, headers):
+            title_el = item.find("title")
+            link_el = item.find("link")
+            if not title_el or not link_el:
+                continue
+            title = _normalize_google_title(title_el.text or "")
+            link = link_el.text or ""
+            output[title] = f"{title}\nSource: {link}"
+    except requests.RequestException:
+        pass
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_mx_news(), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_NG.py
+++ b/python/scrape_NG.py
@@ -1,108 +1,134 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape recent Nigerian National Assembly bill pages (NASS).
+
+Parses the homepage for bill links, follows a limited number of detail pages,
+and falls back to a legacy JSON endpoint if needed. Prints JSON (UTF-8).
+
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import json
-import requests
-import datetime
-import ssl
-from bs4 import BeautifulSoup
-import warnings
-import urllib3
 import re
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+import requests
+import urllib3
+from bs4 import BeautifulSoup
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+BASE_URL = "https://nass.gov.ng"
+REQUEST_TIMEOUT = 15
+MAX_BILLS = 10
+MAX_TITLE_LEN = 250
 
-output = {}
 
-base_url = "https://nass.gov.ng"
-header = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
-}
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-try:
-    # 1. Fetch homepage to get most recent bills
-    response = requests.get(base_url, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
-        soup = BeautifulSoup(response.content, 'html.parser')
-        
-        # Look for the Recent Bills section
-        # They are in a ul with class 'testimonials-grid'
-        bill_links = []
+
+def scrape_nass_bills() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
+    }
+
+    try:
+        response = requests.get(
+            BASE_URL,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+    except requests.RequestException:
+        response = None
+
+    bill_links: list[str] = []
+
+    if response is not None and response.status_code == 200:
+        soup = BeautifulSoup(response.content, "html.parser")
         recent_section = soup.find("h3", string=re.compile("Recent Bills", re.I))
         if recent_section:
             container = recent_section.find_parent("div", class_="nobottommargin")
             if container:
-                links = container.find_all("a", href=re.compile(r"/documents/bill/\d+"))
-                for link in links:
-                    url = base_url + link.get("href")
+                for link in container.find_all("a", href=re.compile(r"/documents/bill/\d+")):
+                    url = BASE_URL + link.get("href", "")
                     if url not in bill_links:
                         bill_links.append(url)
-        
-        # Fallback: search all bill links if specific section not found
+
         if not bill_links:
-            links = soup.find_all("a", href=re.compile(r"/documents/bill/\d+"))
-            for link in links:
-                url = base_url + link.get("href")
+            for link in soup.find_all("a", href=re.compile(r"/documents/bill/\d+")):
+                url = BASE_URL + link.get("href", "")
                 if url not in bill_links:
                     bill_links.append(url)
 
-        # 2. Fetch each bill detail (limit to 10 for performance)
-        for bill_url in bill_links[:10]:
+        for bill_url in bill_links[:MAX_BILLS]:
             try:
-                det_resp = requests.get(bill_url, headers=header, timeout=10, verify=False)
-                if det_resp.status_code == 200:
-                    det_soup = BeautifulSoup(det_resp.content, 'html.parser')
-                    
-                    # Find title - it's usually in a <p><strong>...</strong></p> inside product-desc
-                    title = ""
-                    desc = ""
-                    
-                    product_desc = det_soup.find("div", class_="product-desc")
-                    if product_desc:
-                        strong_p = product_desc.find("p", recursive=False)
-                        if strong_p:
-                            title = strong_p.get_text().strip()
-                        
-                        # Metadata
-                        meta = det_soup.find("div", class_="product-meta")
-                        meta_text = meta.get_text(separator=" | ").strip() if meta else ""
-                        
-                        desc = f"{title}\n\nDetails: {meta_text}\nSource: {bill_url}"
-                    
-                    if not title:
-                        # Fallback title from the link text in homepage if possible or just use a placeholder
-                        title = "Nigerian Legislative Bill " + bill_url.split("/")[-1]
-                    
-                    # Clean up title
-                    title = re.sub(r'\s+', ' ', title)
-                    if len(title) > 250:
-                        title = title[:247] + "..."
-                    
-                    output[title] = desc
-            except:
+                det_resp = requests.get(
+                    bill_url,
+                    headers=headers,
+                    timeout=10,
+                    verify=False,
+                )
+            except requests.RequestException:
                 continue
 
-except Exception:
-    pass
+            if det_resp.status_code != 200:
+                continue
 
-# Fallback: if homepage failed, try the AJAX endpoint but it seems older
-if not output:
+            det_soup = BeautifulSoup(det_resp.content, "html.parser")
+            title = ""
+            desc = ""
+
+            product_desc = det_soup.find("div", class_="product-desc")
+            if product_desc:
+                strong_p = product_desc.find("p", recursive=False)
+                if strong_p:
+                    title = strong_p.get_text().strip()
+
+                meta = det_soup.find("div", class_="product-meta")
+                meta_text = meta.get_text(separator=" | ").strip() if meta else ""
+                desc = f"{title}\n\nDetails: {meta_text}\nSource: {bill_url}"
+
+            if not title:
+                title = "Nigerian Legislative Bill " + bill_url.split("/")[-1]
+
+            title = re.sub(r"\s+", " ", title)
+            if len(title) > MAX_TITLE_LEN:
+                title = title[: MAX_TITLE_LEN - 3] + "..."
+
+            output[title] = desc
+
+    if output:
+        return output
+
     try:
         ajax_url = "https://nass.gov.ng/documents/bill_track/"
-        resp = requests.get(ajax_url, headers=header, timeout=10, verify=False)
+        resp = requests.get(ajax_url, headers=headers, timeout=10, verify=False)
         data = resp.json()
-        for item in data.get('data', [])[:10]:
-            title = item[0].strip()
-            bill_id = item[6]
-            chamber = item[1]
-            if len(title) > 250:
-                title = title[:247] + "..."
-            output[title] = f"{item[0]}\nChamber: {chamber}\nSource: {base_url}/documents/bill/{bill_id}"
-    except:
-        pass
+    except (requests.RequestException, ValueError):
+        return output
 
-print(json.dumps(output, ensure_ascii=False))
+    for item in data.get("data", [])[:MAX_BILLS]:
+        if not isinstance(item, (list, tuple)) or len(item) < 7:
+            continue
+        title = item[0].strip()
+        bill_id = item[6]
+        chamber = item[1]
+        if len(title) > MAX_TITLE_LEN:
+            title = title[: MAX_TITLE_LEN - 3] + "..."
+        output[title] = f"{item[0]}\nChamber: {chamber}\nSource: {BASE_URL}/documents/bill/{bill_id}"
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_nass_bills(), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_NL.py
+++ b/python/scrape_NL.py
@@ -1,82 +1,105 @@
-#!/usr/bin/env python
-import json
-import requests
+#!/usr/bin/env python3
+"""
+Scrape recent Dutch Tweede Kamer legislation cases via OData.
+
+Filters government and private member bills to roughly the last 90 days and
+prints JSON mapping citeertitel (or titel) to description with source URL.
+
+Dependencies: requests, urllib3
+"""
+
+from __future__ import annotations
+
 import datetime
-import ssl
+import json
+
+import requests
 import urllib3
 
-# Suppress InsecureRequestWarning
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+API_URL = "https://gegevensmagazijn.tweedekamer.nl/OData/v4/2.0/Zaak"
+REQUEST_TIMEOUT = 15
+RECENT_DAYS = 90
+MAX_TITLE_LEN = 250
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
 
-output = {}
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-today = datetime.datetime.now()
-three_months_ago = today - datetime.timedelta(days=90)
 
-# Tweede Kamer OData API v2.0
-# Filters for 'Wetgeving' (Government bills) and 'Initiatiefwetgeving' (Private member bills)
-url = "https://gegevensmagazijn.tweedekamer.nl/OData/v4/2.0/Zaak"
-params = {
-    "$filter": "Soort eq 'Wetgeving' or Soort eq 'Initiatiefwetgeving'",
-    "$expand": "Kamerstukdossier",
-    "$orderby": "GestartOp desc",
-    "$top": 50
-}
+def scrape_tweede_kamer() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    today = datetime.datetime.now()
+    cutoff = today - datetime.timedelta(days=RECENT_DAYS)
+    output: dict[str, str] = {}
 
-header = {
-    "accept": "application/json",
-    "User-Agent": "Mozilla/5.0"
-}
+    params = {
+        "$filter": "Soort eq 'Wetgeving' or Soort eq 'Initiatiefwetgeving'",
+        "$expand": "Kamerstukdossier",
+        "$orderby": "GestartOp desc",
+        "$top": 50,
+    }
+    headers = {
+        "accept": "application/json",
+        "User-Agent": "Mozilla/5.0",
+    }
 
-try:
-    response = requests.get(url, params=params, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
+    try:
+        response = requests.get(
+            API_URL,
+            params=params,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+        if response.status_code != 200:
+            return output
         data = response.json()
-        for item in data.get('value', []):
-            # GestartOp format: "2026-03-03T00:00:00+01:00"
-            date_str = item.get('GestartOp', '')
-            if not date_str:
-                continue
-                
-            try:
-                item_date = datetime.datetime.strptime(date_str.split('T')[0], "%Y-%m-%d")
-                if item_date >= three_months_ago:
-                    # Citeertitel is usually the short name, Titel is the full official name
-                    short_title = item.get('Citeertitel')
-                    full_title = item.get('Titel')
-                    bill_nr = item.get('Nummer')
-                    
-                    title = short_title if short_title else full_title
-                    if not title:
-                        continue
-                        
-                    # Truncate if extremely long
-                    if len(title) > 250:
-                        title = title[:247] + "..."
-                    
-                    # Description
-                    desc = full_title if full_title else title
-                    
-                    # Link to the case on the Tweede Kamer website
-                    # New format uses the Kamerstukdossier number if available
-                    dossier = item.get('Kamerstukdossier', [])
-                    if dossier and isinstance(dossier, list) and len(dossier) > 0:
-                        bill_nr_official = dossier[0].get('Nummer')
-                        link = f"https://www.tweedekamer.nl/kamerstukken/wetsvoorstellen/detail?cfg=wetsvoorsteldetails&qry=wetsvoorstel%3A{bill_nr_official}"
-                    else:
-                        # Fallback to Nummer (e.g. 2025Z22479) which works with id parameter
-                        link = f"https://www.tweedekamer.nl/kamerstukken/wetsvoorstellen/detail?id={item.get('Nummer')}"
-                    
-                    desc = f"{desc}\nSource: {link}"
-                    output[title] = desc
-            except Exception:
-                continue
-except Exception:
-    pass
+    except (requests.RequestException, ValueError):
+        return output
 
-print(json.dumps(output))
+    for item in data.get("value", []):
+        date_str = item.get("GestartOp", "")
+        if not date_str:
+            continue
+        try:
+            item_date = datetime.datetime.strptime(date_str.split("T")[0], "%Y-%m-%d")
+        except ValueError:
+            continue
+        if item_date < cutoff:
+            continue
+
+        short_title = item.get("Citeertitel")
+        full_title = item.get("Titel")
+
+        title = short_title or full_title
+        if not title:
+            continue
+        if len(title) > MAX_TITLE_LEN:
+            title = title[: MAX_TITLE_LEN - 3] + "..."
+
+        desc = full_title or title
+        dossier = item.get("Kamerstukdossier", [])
+        if dossier and isinstance(dossier, list) and dossier:
+            bill_nr_official = dossier[0].get("Nummer")
+            link = (
+                "https://www.tweedekamer.nl/kamerstukken/wetsvoorstellen/detail?"
+                f"cfg=wetsvoorsteldetails&qry=wetsvoorstel%3A{bill_nr_official}"
+            )
+        else:
+            link = (
+                "https://www.tweedekamer.nl/kamerstukken/wetsvoorstellen/detail?"
+                f"id={item.get('Nummer')}"
+            )
+
+        desc = f"{desc}\nSource: {link}"
+        output[title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_tweede_kamer()))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_NO.py
+++ b/python/scrape_NO.py
@@ -1,65 +1,54 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape Norwegian Storting representative proposals from the official RSS feed.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Prints a flat list alternating cleaned description text and item links.
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
-import sys
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
+import re
+
 import requests
 import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import re
-#import numpy as np
+from bs4 import BeautifulSoup
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
-
-output = []
-
-# URl needs to be dynamic
-import datetime
-today = datetime.datetime.now()
-year = today.year
-errorcount = 0
-# Read the XML file
-url = 'https://www.stortinget.no/no/Stottemeny/RSS/Representantforslag/'
-xml = requests.get(url, verify=False)
-soup = BeautifulSoup(xml.content, features='xml')
-items = soup.find_all("item")
-for item in items:
-    title = item.find("description").getText()
-    title = re.sub(r'(fra\b).*(?=\bom)','',title)
-    desc = item.find("link").getText()
-    output.append(title)
-    output.append(desc) 
-
-print(output)
-
-#print(topicno)
-#print(status)
-#print(url)
-#print(uzeit) 
-#list_of_contents.remove("\n")
-#list_of_contents.remove(" ")
+RSS_URL = "https://www.stortinget.no/no/Stottemeny/RSS/Representantforslag/"
+REQUEST_TIMEOUT = 30
 
 
-#print(list_of_contents)
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-#print(topiclist)
 
-#f = open('BT_Tagesordnung.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in output))
-#f.close
+def fetch_representative_proposals() -> list[str]:
+    """Return alternating title-like text and link for each RSS item."""
+    _disable_insecure_request_warnings()
+    response = requests.get(RSS_URL, timeout=REQUEST_TIMEOUT, verify=False)
+    response.raise_for_status()
 
-#f = open('BT_Tagesordnung.txt', 'a')
-#f.write("\n".join(str(item) for item in url))
-#f.close
+    soup = BeautifulSoup(response.content, features="xml")
+    output: list[str] = []
+
+    for item in soup.find_all("item"):
+        desc_el = item.find("description")
+        link_el = item.find("link")
+        if not desc_el or not link_el:
+            continue
+        title = desc_el.getText()
+        title = re.sub(r"(fra\b).*(?=\bom)", "", title)
+        desc = link_el.getText()
+        output.append(title)
+        output.append(desc)
+
+    return output
+
+
+def main() -> None:
+    print(fetch_representative_proposals())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_PL.py
+++ b/python/scrape_PL.py
@@ -1,85 +1,109 @@
-#!/usr/bin/env python
-import json
-import requests
+#!/usr/bin/env python3
+"""
+Scrape recent bills from the Polish Sejm public API (term 10).
+
+Fetches a window of bills, filters by receipt date (last ~90 days), and prints
+JSON mapping a prefixed title to status and source URL.
+
+Dependencies: requests, urllib3
+"""
+
+from __future__ import annotations
+
 import datetime
-import ssl
+import json
 import sys
+
+import requests
 import urllib3
 
-# Suppress InsecureRequestWarning
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+API_URL = "https://api.sejm.gov.pl/sejm/term10/bills"
+REQUEST_TIMEOUT = 15
+RECENT_DAYS = 90
+MAX_TITLE_LEN = 250
 
-# Ignore SSL certificate errors for stdlib if needed
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
 
-output = {}
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-today = datetime.datetime.now()
-three_months_ago = today - datetime.timedelta(days=90)
 
-# Sejm API term 10 (started Nov 2023, active in 2026)
-url = "https://api.sejm.gov.pl/sejm/term10/bills"
-# We fetch the most recent batch (approx 1000 bills exist)
-params = {
-    "limit": 100,
-    "offset": 900
-}
+def scrape_sejm_bills() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    today = datetime.datetime.now()
+    cutoff = today - datetime.timedelta(days=RECENT_DAYS)
+    output: dict[str, str] = {}
 
-header = {
-    "accept": "application/json",
-    "User-Agent": "Mozilla/5.0"
-}
+    params = {"limit": 100, "offset": 900}
+    headers = {
+        "accept": "application/json",
+        "User-Agent": "Mozilla/5.0",
+    }
 
-response = requests.get(url, params=params, headers=header, timeout=15, verify=False)
-if response.status_code == 200:
-    data = response.json()
-    # The list is usually chronological by receipt, but we check just in case
+    response = requests.get(
+        API_URL,
+        params=params,
+        headers=headers,
+        timeout=REQUEST_TIMEOUT,
+        verify=False,
+    )
+    if response.status_code != 200:
+        print(
+            f"Error: API returned status code {response.status_code}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        data = response.json()
+    except ValueError:
+        return output
+
+    if not isinstance(data, list):
+        return output
+
     for item in data:
-        date_str = item.get('dateOfReceipt', '')
+        if not isinstance(item, dict):
+            continue
+        date_str = item.get("dateOfReceipt", "")
         if not date_str:
             continue
-            
         try:
             item_date = datetime.datetime.strptime(date_str, "%Y-%m-%d")
-            if item_date >= three_months_ago:
-                title = item.get('title', '').strip()
-                if not title:
-                    continue
-                
-                # Bill number and status
-                bill_nr = item.get('number', '')
-                status = item.get('status', '')
-                
-                # Detailed description
-                summary = item.get('description', '')
-                
-                # Official link to the bill's legislative process
-                # Using the bill number or print number
-                print_num = item.get('print', '')
-                if print_num:
-                    link = f"https://www.sejm.gov.pl/Sejm10.nsf/PrzebiegProc.xsp?nr={print_num}"
-                else:
-                    # Fallback to search if print not available yet
-                    link = f"https://api.sejm.gov.pl/sejm/term10/bills/{item.get('number')}"
-
-                desc = ""
-                if summary:
-                    desc = f"{summary}\n\n"
-                
-                desc += f"Status: {status}\nSource: {link}"
-                
-                # Prefix title with bill reference for clarity
-                full_title = f"{bill_nr}: {title}"
-                if len(full_title) > 250:
-                    full_title = full_title[:247] + "..."
-                    
-                output[full_title] = desc
-        except Exception:
+        except ValueError:
             continue
-else:
-    sys.stderr.write(f"Error: API returned status code {response.status_code}\n")
-    sys.exit(1)
+        if item_date < cutoff:
+            continue
 
-print(json.dumps(output))
+        title = (item.get("title") or "").strip()
+        if not title:
+            continue
+
+        bill_nr = item.get("number", "")
+        status = item.get("status", "")
+        summary = item.get("description", "")
+        print_num = item.get("print", "")
+        if print_num:
+            link = f"https://www.sejm.gov.pl/Sejm10.nsf/PrzebiegProc.xsp?nr={print_num}"
+        else:
+            link = f"https://api.sejm.gov.pl/sejm/term10/bills/{item.get('number')}"
+
+        desc = ""
+        if summary:
+            desc = f"{summary}\n\n"
+        desc += f"Status: {status}\nSource: {link}"
+
+        full_title = f"{bill_nr}: {title}"
+        if len(full_title) > MAX_TITLE_LEN:
+            full_title = full_title[: MAX_TITLE_LEN - 3] + "..."
+
+        output[full_title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_sejm_bills()))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_SE.py
+++ b/python/scrape_SE.py
@@ -1,67 +1,58 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape Swedish Riksdag committee proposals from the public RSS document list.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Prints a flat list: title, link+date line, per item.
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
-import sys
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import requests
 import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import re
-#import numpy as np
+from bs4 import BeautifulSoup
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
-
-output = []
-
-# URl needs to be dynamic
-import datetime
-today = datetime.datetime.now()
-year = today.year
-errorcount = 0
-# Read the XML file
-url = 'https://data.riksdagen.se/dokumentlista/?avd=dokument&doktyp=bet&utskforslag=1&sort=debattdag&sortorder=asc&utformat=rss'
-xml = requests.get(url, verify=False)
-soup = BeautifulSoup(xml.content, features='xml')
-items = soup.find_all("item")
-for item in items:
-    title = item.find("title").getText()
-    link = item.find("link").getText()
-    desc = item.find("description").getText().strip()
-    date = desc[-10:]
-    desc = link + "\n" + date
-    output.append(title)
-    output.append(desc) 
-
-print(output)
-
-#print(topicno)
-#print(status)
-#print(url)
-#print(uzeit) 
-#list_of_contents.remove("\n")
-#list_of_contents.remove(" ")
+RSS_URL = (
+    "https://data.riksdagen.se/dokumentlista/?avd=dokument&doktyp=bet&"
+    "utskforslag=1&sort=debattdag&sortorder=asc&utformat=rss"
+)
+REQUEST_TIMEOUT = 30
 
 
-#print(list_of_contents)
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-#print(topiclist)
 
-#f = open('BT_Tagesordnung.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in output))
-#f.close
+def fetch_riksdag_rss() -> list[str]:
+    """Return flattened entries from the Riksdagen RSS feed."""
+    _disable_insecure_request_warnings()
+    response = requests.get(RSS_URL, timeout=REQUEST_TIMEOUT, verify=False)
+    response.raise_for_status()
 
-#f = open('BT_Tagesordnung.txt', 'a')
-#f.write("\n".join(str(item) for item in url))
-#f.close
+    soup = BeautifulSoup(response.content, features="xml")
+    output: list[str] = []
+
+    for item in soup.find_all("item"):
+        title_el = item.find("title")
+        link_el = item.find("link")
+        desc_el = item.find("description")
+        if not title_el or not link_el or not desc_el:
+            continue
+        title = title_el.getText()
+        link = link_el.getText()
+        description = desc_el.getText().strip()
+        date = description[-10:]
+        desc = link + "\n" + date
+        output.append(title)
+        output.append(desc)
+
+    return output
+
+
+def main() -> None:
+    print(fetch_riksdag_rss())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_TH.py
+++ b/python/scrape_TH.py
@@ -1,17 +1,28 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape recent Thai bill metadata from the Politigraph GraphQL API.
+
+Maps a shortened display title to full title, status, dates, and parliament URL.
+
+Dependencies: requests, urllib3
+"""
+
+from __future__ import annotations
+
 import json
+
 import requests
-import warnings
 import urllib3
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+API_URL = "https://politigraph.wevis.info/graphql"
+REQUEST_TIMEOUT = 15
 
-output = {}
-api_url = "https://politigraph.wevis.info/graphql"
 
-# Query for the 30 most recent bills (ordered by their database ID or relevant sequence)
-query = """
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+GRAPHQL_QUERY = """
 {
   bills(limit: 30) {
     id
@@ -23,37 +34,67 @@ query = """
 }
 """
 
-try:
-    response = requests.post(api_url, json={'query': query}, timeout=15, verify=False)
-    if response.status_code == 200:
+
+def scrape_thailand_bills() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+
+    try:
+        response = requests.post(
+            API_URL,
+            json={"query": GRAPHQL_QUERY},
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+    except requests.RequestException:
+        return output
+
+    if response.status_code != 200:
+        return output
+
+    try:
         data = response.json()
-        bills = data.get('data', {}).get('bills', [])
-        
-        for bill in bills:
-            title_raw = bill.get('title', '').strip()
-            title_clean = title_raw.replace("พ.ศ. ....", "").strip()
-            
-            lis_id = bill.get('lis_id')
-            status = bill.get('status', 'N/A')
-            proposal_date = bill.get('proposal_date', 'N/A')
-            
-            # Official Parliament Section 77 URL
-            official_url = f"https://www.parliament.go.th/section77/survey_detail.php?id={lis_id}" if lis_id else ""
-            
-            display_title = title_clean
-            if len(display_title) > 70:
-                display_title = display_title[:67] + "..."
-            
-            desc = f"{title_raw}\n\n"
-            desc += f"Status: {status}\n"
-            desc += f"Proposed date: {proposal_date}\n"
-            if official_url:
-                desc += f"Source: {official_url}"
-            
-            if display_title:
-                output[display_title] = desc
+    except ValueError:
+        return output
 
-except Exception:
-    pass
+    bills = data.get("data", {}).get("bills", [])
+    if not isinstance(bills, list):
+        return output
 
-print(json.dumps(output, ensure_ascii=False))
+    for bill in bills:
+        if not isinstance(bill, dict):
+            continue
+        title_raw = (bill.get("title") or "").strip()
+        title_clean = title_raw.replace("พ.ศ. ....", "").strip()
+
+        lis_id = bill.get("lis_id")
+        status = bill.get("status", "N/A")
+        proposal_date = bill.get("proposal_date", "N/A")
+        official_url = (
+            f"https://www.parliament.go.th/section77/survey_detail.php?id={lis_id}"
+            if lis_id
+            else ""
+        )
+
+        display_title = title_clean
+        if len(display_title) > 70:
+            display_title = display_title[:67] + "..."
+
+        desc = f"{title_raw}\n\n"
+        desc += f"Status: {status}\n"
+        desc += f"Proposed date: {proposal_date}\n"
+        if official_url:
+            desc += f"Source: {official_url}"
+
+        if display_title:
+            output[display_title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_thailand_bills(), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_TR.py
+++ b/python/scrape_TR.py
@@ -1,62 +1,104 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape recent Turkish Grand National Assembly incoming papers list.
+
+Follows a few list rows into detail pages, regex-extracts proposal lines, and
+prints JSON mapping a short title to full line plus source URL.
+
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import json
-import requests
 import re
-from bs4 import BeautifulSoup
-import warnings
+
+import requests
 import urllib3
+from bs4 import BeautifulSoup
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+BASE_URL = "https://tbmm.gov.tr"
+LIST_URL = f"{BASE_URL}/Gundem/GelenKagitlarListe"
+REQUEST_TIMEOUT = 15
+MAX_LIST_ROWS = 5
+MAX_TITLE_LEN = 250
 
-output = {}
-base_url = "https://tbmm.gov.tr"
-list_url = f"{base_url}/Gundem/GelenKagitlarListe"
 
-header = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
-}
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-try:
-    response = requests.get(list_url, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
-        soup = BeautifulSoup(response.content, 'html.parser')
-        table = soup.find("table")
-        if table:
-            # Most recent 5 pages
-            rows = table.find_all("tr")[:5]
-            for row in rows:
-                link_tag = row.find("a")
-                if link_tag:
-                    detail_url = base_url + link_tag.get("href")
-                    det_resp = requests.get(detail_url, headers=header, timeout=10, verify=False)
-                    if det_resp.status_code == 200:
-                        det_soup = BeautifulSoup(det_resp.content, 'html.parser')
-                        text = det_soup.get_text()
-                        
-                        # Normalize spaces and newlines
-                        text = text.replace('\xa0', ' ')
-                        text = re.sub(r'\s+', ' ', text)
-                        
-                        # Search for proposals
-                        # 1.- Düzce Milletvekili ...; Sosyal Hizmetler Kanunu ... (2/3566)
-                        # The pattern is: digit.- ... ; Title (2/digit)
-                        matches = re.finditer(r'(\d+\.- .*?; (.*?) \((2/\d+)\))', text)
-                        
-                        for m in matches:
-                            full_match = m.group(1).strip()
-                            title_core = m.group(2).strip()
-                            proposal_id = m.group(3).strip()
-                            
-                            title = f"{title_core} {proposal_id}"
-                            
-                            if len(title) > 250:
-                                title = title[:247] + "..."
-                            
-                            desc = f"{full_match}\nSource: {detail_url}"
-                            output[title] = desc
 
-except Exception:
-    pass
+def scrape_tbmm_gundem() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
+    }
 
-print(json.dumps(output))
+    try:
+        response = requests.get(
+            LIST_URL,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+    except requests.RequestException:
+        return output
+
+    if response.status_code != 200:
+        return output
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    table = soup.find("table")
+    if not table:
+        return output
+
+    for row in table.find_all("tr")[:MAX_LIST_ROWS]:
+        link_tag = row.find("a")
+        if not link_tag:
+            continue
+        href = link_tag.get("href")
+        if not href:
+            continue
+        detail_url = BASE_URL + href
+
+        try:
+            det_resp = requests.get(
+                detail_url,
+                headers=headers,
+                timeout=10,
+                verify=False,
+            )
+        except requests.RequestException:
+            continue
+
+        if det_resp.status_code != 200:
+            continue
+
+        det_soup = BeautifulSoup(det_resp.content, "html.parser")
+        text = det_soup.get_text()
+        text = text.replace("\xa0", " ")
+        text = re.sub(r"\s+", " ", text)
+
+        for match in re.finditer(r"(\d+\.- .*?; (.*?) \((2/\d+)\))", text):
+            full_match = match.group(1).strip()
+            title_core = match.group(2).strip()
+            proposal_id = match.group(3).strip()
+            title = f"{title_core} {proposal_id}"
+            if len(title) > MAX_TITLE_LEN:
+                title = title[: MAX_TITLE_LEN - 3] + "..."
+            desc = f"{full_match}\nSource: {detail_url}"
+            output[title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_tbmm_gundem()))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_US.py
+++ b/python/scrape_US.py
@@ -1,73 +1,60 @@
-#!/usr/bin/env python
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+#!/usr/bin/env python3
+"""
+Scrape titles and links from the U.S. Congress \"most viewed bills\" RSS feed.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Parses the first RSS item's embedded HTML list and prints a flat Python list
+(alternating title strings and href strings) for stdout consumption.
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
-import sys
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
+import re
+
 import requests
 import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import re
-#import numpy as np
+from bs4 import BeautifulSoup
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
-
-output = []
-
-# URl needs to be dynamic
-import datetime
-today = datetime.datetime.now()
-year = today.year
-errorcount = 0
-# Read the XML file
-url = 'https://www.congress.gov/rss/most-viewed-bills.xml'
-xml = requests.get(url, verify=False)
-soup = BeautifulSoup(xml.content, features='xml')
-content = soup.find("item").getText()
-lines = content.split("<li>")
-for line in lines:
-    title = re.search('>(.+?)</li>', line)
-    if title:
-        title = title.group(1)
-        title = title.replace("</a>", "")
-        output.append(title)
-    desc = re.search('href=(.+?)>', line)
-    if desc:
-        desc = desc.group(1)
-        desc = desc.replace("'", "")
-        output.append(desc)
-
-# output.append(desc) 
-
-print(output)
-
-#print(topicno)
-#print(status)
-#print(url)
-#print(uzeit) 
-#list_of_contents.remove("\n")
-#list_of_contents.remove(" ")
+RSS_URL = "https://www.congress.gov/rss/most-viewed-bills.xml"
+REQUEST_TIMEOUT = 30
 
 
-#print(list_of_contents)
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-#print(topiclist)
 
-#f = open('BT_Tagesordnung.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in output))
-#f.close
+def fetch_most_viewed_bills() -> list[str]:
+    """Return alternating titles and link hrefs extracted from the RSS payload."""
+    _disable_insecure_request_warnings()
+    response = requests.get(RSS_URL, timeout=REQUEST_TIMEOUT, verify=False)
+    response.raise_for_status()
 
-#f = open('BT_Tagesordnung.txt', 'a')
-#f.write("\n".join(str(item) for item in url))
-#f.close
+    soup = BeautifulSoup(response.content, features="xml")
+    first_item = soup.find("item")
+    if not first_item or first_item.getText() is None:
+        return []
+
+    content = first_item.getText()
+    output: list[str] = []
+
+    for line in content.split("<li>"):
+        title_match = re.search(r">(.+?)</li>", line)
+        if title_match:
+            title = title_match.group(1).replace("</a>", "")
+            output.append(title)
+        desc_match = re.search(r"href=(.+?)>", line)
+        if desc_match:
+            desc = desc_match.group(1).replace("'", "")
+            output.append(desc)
+
+    return output
+
+
+def main() -> None:
+    result: list[str] = fetch_most_viewed_bills()
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_ZA.py
+++ b/python/scrape_ZA.py
@@ -1,57 +1,96 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+"""
+Scrape South African bill metadata from the PMG API.
+
+Prints JSON mapping title (with bill code when present) to details and web URL.
+
+Dependencies: requests, urllib3
+"""
+
+from __future__ import annotations
+
 import json
+
 import requests
-import warnings
 import urllib3
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+API_URL = "https://api.pmg.org.za/bill/"
+REQUEST_TIMEOUT = 15
+MAX_TITLE_LEN = 250
 
-output = {}
-api_url = "https://api.pmg.org.za/bill/"
 
-header = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
-}
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-try:
-    response = requests.get(api_url, headers=header, timeout=15, verify=False)
-    if response.status_code == 200:
+
+def scrape_pmg_bills() -> dict[str, str]:
+    _disable_insecure_request_warnings()
+    output: dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
+    }
+
+    try:
+        response = requests.get(
+            API_URL,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+        )
+    except requests.RequestException:
+        return output
+
+    if response.status_code != 200:
+        return output
+
+    try:
         data = response.json()
-        bills = data.get('results', [])
-        
-        for bill in bills:
-            title = bill.get('title', '').strip()
-            code = bill.get('code', '')
-            if code:
-                title = f"{title} ({code})"
-            
-            # Metadata for description
-            year = bill.get('year')
-            intro_date = bill.get('date_of_introduction')
-            intro_by = bill.get('introduced_by')
-            status = bill.get('status', {}).get('description') if bill.get('status') else "N/A"
-            bill_type = bill.get('type', {}).get('description') if bill.get('type') else "N/A"
-            
-            # Source URL (API gives API URL, we want the website URL if possible)
-            # PMG website URLs usually follow: https://pmg.org.za/bill/{id}/
-            bill_id = bill.get('id')
-            web_url = f"https://pmg.org.za/bill/{bill_id}/"
-            
-            if len(title) > 250:
-                title = title[:247] + "..."
-            
-            desc = f"{bill.get('title')}\n\n"
-            desc += f"Code: {code}\n"
-            desc += f"Status: {status}\n"
-            desc += f"Type: {bill_type}\n"
-            desc += f"Introduced by: {intro_by} on {intro_date}\n"
-            desc += f"Source: {web_url}"
-            
-            if title:
-                output[title] = desc
+    except ValueError:
+        return output
 
-except Exception:
-    pass
+    bills = data.get("results", [])
+    if not isinstance(bills, list):
+        return output
 
-print(json.dumps(output, ensure_ascii=False))
+    for bill in bills:
+        if not isinstance(bill, dict):
+            continue
+        title = (bill.get("title") or "").strip()
+        code = bill.get("code", "")
+        if code:
+            title = f"{title} ({code})"
+
+        intro_date = bill.get("date_of_introduction")
+        intro_by = bill.get("introduced_by")
+        status_obj = bill.get("status") or {}
+        status = status_obj.get("description") if isinstance(status_obj, dict) else "N/A"
+        type_obj = bill.get("type") or {}
+        bill_type = type_obj.get("description") if isinstance(type_obj, dict) else "N/A"
+        bill_id = bill.get("id")
+        web_url = f"https://pmg.org.za/bill/{bill_id}/"
+
+        if len(title) > MAX_TITLE_LEN:
+            title = title[: MAX_TITLE_LEN - 3] + "..."
+
+        desc = f"{bill.get('title')}\n\n"
+        desc += f"Code: {code}\n"
+        desc += f"Status: {status}\n"
+        desc += f"Type: {bill_type}\n"
+        desc += f"Introduced by: {intro_by} on {intro_date}\n"
+        desc += f"Source: {web_url}"
+
+        if title:
+            output[title] = desc
+
+    return output
+
+
+def main() -> None:
+    print(json.dumps(scrape_pmg_bills(), ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_ohchr.py
+++ b/python/scrape_ohchr.py
@@ -1,82 +1,113 @@
 #!/usr/bin/env python3
+"""
+Scrape UN Human Rights Council session resolution tables from ohchr.org.
+
+Iterates session numbers until a page returns 404 or lacks a table, and prints a
+flat list of resolution titles and descriptions.
+
+Dependencies: beautifulsoup4, requests, urllib3
+"""
+
+from __future__ import annotations
+
 import requests
 import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 from bs4 import BeautifulSoup
-import datetime
 
-today = datetime.datetime.now()
-output = []
+SESSION_START = 49
+SESSION_LIMIT = 62
+REQUEST_TIMEOUT = 15
 
-# Latest session is 61 (Feb-Mar 2026), starting from 49 (new format)
-session = 49
-max_session = 62 # To avoid infinite loops
 
-while session < max_session:
-    url = f"https://www.ohchr.org/en/hr-bodies/hrc/regular-sessions/session{session}/res-dec-stat"
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def session_url(session_num: int) -> str:
+    return (
+        "https://www.ohchr.org/en/hr-bodies/hrc/regular-sessions/"
+        f"session{session_num}/res-dec-stat"
+    )
+
+
+def scrape_hrc_resolutions() -> list[str]:
+    _disable_insecure_request_warnings()
+    output: list[str] = []
     headers = {
-        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-        'Accept-Language': 'en-US,en;q=0.9',
-        'Accept-Encoding': 'gzip, deflate, br',
-        'DNT': '1',
-        'Connection': 'keep-alive',
-        'Upgrade-Insecure-Requests': '1',
-        'Sec-Fetch-Dest': 'document',
-        'Sec-Fetch-Mode': 'navigate',
-        'Sec-Fetch-Site': 'none',
-        'Sec-Fetch-User': '?1',
-        'Cache-Control': 'max-age=0',
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        ),
+        "Accept": (
+            "text/html,application/xhtml+xml,application/xml;q=0.9,"
+            "image/avif,image/webp,image/apng,*/*;q=0.8,"
+            "application/signed-exchange;v=b3;q=0.7"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br",
+        "DNT": "1",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+        "Cache-Control": "max-age=0",
     }
-    try:
-        session_obj = requests.Session()
-        html = session_obj.get(url, verify=False, timeout=15, headers=headers)
+
+    session_num = SESSION_START
+    client = requests.Session()
+
+    while session_num < SESSION_LIMIT:
+        url = session_url(session_num)
+        try:
+            html = client.get(url, verify=False, timeout=REQUEST_TIMEOUT, headers=headers)
+        except requests.exceptions.RequestException:
+            break
+
         if html.status_code == 404:
             break
         html.raise_for_status()
-    except requests.exceptions.RequestException as e:
-        break
 
-    soup = BeautifulSoup(html.text, 'html.parser')
-    # The new site uses views-table class
-    table = soup.find("table")
-    
-    if table:
-        rows = table.find_all('tr')
-        for row in rows:
-            cells = row.find_all('td')
-            if len(cells) >= 2:
-                # First cell: Adopted Text (Number and Link)
-                adopted_text_cell = cells[0]
-                link_tag = adopted_text_cell.find('a')
-                if not link_tag:
-                    continue
-                
-                number = link_tag.get_text(strip=True)
-                link = link_tag.get('href')
-                if link and not link.startswith('http'):
-                    link = 'https://www.ohchr.org' + link
+        soup = BeautifulSoup(html.text, "html.parser")
+        table = soup.find("table")
+        if not table:
+            break
 
-                # Second cell: Title
-                title = cells[1].get_text(strip=True)
-                
-                # Full Title
-                full_title = f"HRC {session}/{number} - {title}"
-                full_title = full_title[:255]
-                
-                # Description (including action taken if available)
-                action = ""
-                if len(cells) >= 5:
-                    action = cells[4].get_text(strip=True)
-                
-                desc = f"{title}\nAdopted: {action}\nSource: {link}"
-                
-                output.append(full_title)
-                output.append(desc)
-        
-        session += 1
-    else:
-        # No table found, might be the end or a session with no resolutions yet
-        break
+        for row in table.find_all("tr"):
+            cells = row.find_all("td")
+            if len(cells) < 2:
+                continue
 
-print(output)
+            adopted_cell = cells[0]
+            link_tag = adopted_cell.find("a")
+            if not link_tag:
+                continue
+
+            number = link_tag.get_text(strip=True)
+            link = link_tag.get("href") or ""
+            if link and not link.startswith("http"):
+                link = "https://www.ohchr.org" + link
+
+            title = cells[1].get_text(strip=True)
+            full_title = f"HRC {session_num}/{number} - {title}"[:255]
+
+            action = ""
+            if len(cells) >= 5:
+                action = cells[4].get_text(strip=True)
+
+            desc = f"{title}\nAdopted: {action}\nSource: {link}"
+            output.append(full_title)
+            output.append(desc)
+
+        session_num += 1
+
+    return output
+
+
+def main() -> None:
+    print(scrape_hrc_resolutions())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_unga.py
+++ b/python/scrape_unga.py
@@ -1,77 +1,110 @@
+#!/usr/bin/env python3
+"""
+List UN General Assembly resolution XML files from GitHub and extract metadata.
+
+Uses the GitHub REST API to discover Akoma Ntoso XML assets for a GA session,
+parses doc titles and numbers, and prints a flat Python list (title, UN doc URL).
+
+Dependencies: lxml, requests, urllib3
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
 import requests
 import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 from lxml import etree
 
-session = 79
-output = []
-# GitHub API URL to list files in the repository
-api_url = "https://api.github.com/repos/UNxml/GAresolutions/contents/"+str(session)+"session/English"
+SESSION = 79
+GITHUB_API_URL = (
+    f"https://api.github.com/repos/UNxml/GAresolutions/contents/{SESSION}session/English"
+)
+REQUEST_TIMEOUT = 30
 
-# Headers with your GitHub token (optional, if you're hitting rate limits)
-headers = {
-    "Accept": "application/vnd.github.v3+json",
-    # "Authorization": "token YOUR_GITHUB_TOKEN"  # Uncomment and add your token if needed
-}
+AKN_NS = {"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"}
 
-def get_file_urls(api_url):
-    """Fetches URLs for XML files from the GitHub API."""
-    response = requests.get(api_url, headers=headers, verify=False)
+
+def _disable_insecure_request_warnings() -> None:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def list_xml_download_urls() -> list[str]:
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    response = requests.get(
+        GITHUB_API_URL,
+        headers=headers,
+        verify=False,
+        timeout=REQUEST_TIMEOUT,
+    )
     response.raise_for_status()
-    
-    # List of XML file URLs
-    file_urls = [
+    payload: Any = response.json()
+    if not isinstance(payload, list):
+        return []
+    return [
         item["download_url"]
-        for item in response.json()
-        if item["name"].endswith(".xml")
+        for item in payload
+        if isinstance(item, dict)
+        and str(item.get("name", "")).endswith(".xml")
+        and item.get("download_url")
     ]
-    
-    return file_urls
 
-def parse_xml_from_url(url):
-    """Fetches and parses XML data from a URL."""
-    response = requests.get(url, verify=False)
-    response.raise_for_status()
 
+def parse_resolution_entry(xml_bytes: bytes) -> tuple[str, str] | None:
     try:
-        # Parse the XML content with lxml
-        root = etree.fromstring(response.content)
-        
-        # Define namespaces if present (Akoma Ntoso namespace in this case)
-        namespaces = {'akn': 'http://docs.oasis-open.org/legaldocml/ns/akn/3.0'}
-        
-        # Use XPath to find <span> within <docTitle> with namespaces
-        title = root.xpath(".//akn:docTitle/akn:span[@class='bold']/text()", namespaces=namespaces)
+        root = etree.fromstring(xml_bytes)
+    except etree.XMLSyntaxError:
+        return None
 
-                # Use XPath to find <span> within <docTitle> with namespaces
-        pdf = root.xpath(".//akn:docNumber/text()", namespaces=namespaces)
-        
-        # Print each extracted text
-        for text in title:
-            title = text.strip()
-        output.append(title)
-        
-        for text in pdf:
-            pdf = text.rstrip(".")
-        if any(ch.isdigit() for ch in pdf):
-            desc = 'United Nations General Assembly Resolution\nhttps://docs.un.org/A/RES/'+pdf
-            output.append(desc)
-        else:    
-            output.pop()
-            
-    except etree.XMLSyntaxError as e:
-        print(f"Error parsing XML: {e}")
-        return
+    title_nodes = root.xpath(
+        ".//akn:docTitle/akn:span[@class='bold']/text()",
+        namespaces=AKN_NS,
+    )
+    number_nodes = root.xpath(".//akn:docNumber/text()", namespaces=AKN_NS)
 
-def main():
-    # Get the list of XML file URLs
-    xml_file_urls = get_file_urls(api_url)
-    
-    # Process each XML file
-    for url in xml_file_urls:
+    title_text = title_nodes[-1].strip() if title_nodes else ""
+    if not title_text:
+        return None
 
-        parse_xml_from_url(url)
+    doc_number = number_nodes[-1].rstrip(".") if number_nodes else ""
+    if doc_number and any(ch.isdigit() for ch in doc_number):
+        desc = (
+            "United Nations General Assembly Resolution\n"
+            f"https://docs.un.org/A/RES/{doc_number}"
+        )
+        return title_text, desc
 
-# Run the main function
-main()
-print(output)
+    return None
+
+
+def scrape_ga_resolutions() -> list[str]:
+    _disable_insecure_request_warnings()
+    output: list[str] = []
+
+    for download_url in list_xml_download_urls():
+        try:
+            response = requests.get(
+                download_url,
+                verify=False,
+                timeout=REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+        except requests.RequestException:
+            continue
+
+        parsed = parse_resolution_entry(response.content)
+        if not parsed:
+            continue
+        title_text, desc = parsed
+        output.append(title_text)
+        output.append(desc)
+
+    return output
+
+
+def main() -> None:
+    print(scrape_ga_resolutions())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_unsc.py
+++ b/python/scrape_unsc.py
@@ -1,80 +1,92 @@
 #!/usr/bin/env python3
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+"""
+Scrape UN Security Council adopted resolutions listings for two year pages.
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Fetches the current and next calendar year index pages from un.org, parses the
+main table, and prints a flat list of title and description pairs.
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
+Dependencies: beautifulsoup4
+"""
+
+from __future__ import annotations
+
 import datetime
+import urllib.error
+import urllib.request
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+from bs4 import BeautifulSoup
 
-today = datetime.datetime.now()
-output = []
+USER_AGENT = "Mozilla/5.0"
+YEARS_TO_FETCH = 2
+LIST_PATH = (
+    "https://www.un.org/securitycouncil/content/resolutions-adopted-security-council-"
+)
 
-count = 0
-while count < 2:
-    year = today.year + count
+
+def fetch_year_page(year: int) -> bytes | None:
     req = urllib.request.Request(
-        url='https://www.un.org/securitycouncil/content/resolutions-adopted-security-council-'+str(year), 
-        headers={'User-Agent': 'Mozilla/5.0'}
+        url=f"{LIST_PATH}{year}",
+        headers={"User-Agent": USER_AGENT},
     )
     try:
-        html = urllib.request.urlopen(req).read()
-    except urllib.error.HTTPError as e:
-        if e.getcode() == 404: # check the return code
-            count = count + 1
-            continue
-        raise # if other than 404, raise the error
+        with urllib.request.urlopen(req) as response:
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
 
-    soup = BeautifulSoup(html, 'html.parser')
 
-    section = soup.find("div", {'class': 'field-items'})
-    trs = section.findAll('tr')
+def parse_resolution_rows(html: bytes) -> list[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    section = soup.find("div", {"class": "field-items"})
+    if not section:
+        return []
 
-    for tr in trs:
-        tds = tr.findAll('td')
-        title = []
-        contents = []
-        for id, td in enumerate(tds):          
-                if td.find('a') is not None and id == 0: 
-                    contents.append(td.getText().strip())
-                    contents.append(td.find('a').get('href'))
-                else:
-                    contents.append(td.getText().split("\n")[0])
+    output: list[str] = []
+    for row in section.find_all("tr"):
+        cells = row.find_all("td")
+        contents: list[str] = []
+        for col_idx, cell in enumerate(cells):
+            anchor = cell.find("a")
+            if anchor is not None and col_idx == 0:
+                contents.append(cell.getText().strip())
+                contents.append(anchor.get("href") or "")
+            else:
+                parts = cell.getText().split("\n")
+                contents.append(parts[0] if parts else "")
+
         contents.reverse()
-        
-        if contents:
-            title = contents[0].replace(u'\xa0', u' ')
-            title = title.replace("'", " ")
-            title = contents[3] + " - " + title
-            desc = contents[0] + " \n" + contents[2] + " \n" + contents[1]
-            desc = desc.replace("'", " ")
+        if not contents:
+            continue
 
-            output.append(title)
-            output.append(desc)
+        title = contents[0].replace("\xa0", " ").replace("'", " ")
+        title = contents[3] + " - " + title
+        desc = contents[0] + " \n" + contents[2] + " \n" + contents[1]
+        desc = desc.replace("'", " ")
+        output.append(title)
+        output.append(desc)
 
-    count = count + 1
+    return output
 
-#print(refs)
-#list_of_contents.reverse()
 
-#headings = list_of_contents[0::4]
-#URL = list_of_contents[2::4]
+def scrape_unsc_resolutions() -> list[str]:
+    today = datetime.datetime.now()
+    combined: list[str] = []
 
-print(output)
-#print(headings)
-#print(URL)
+    for offset in range(YEARS_TO_FETCH):
+        year = today.year + offset
+        html = fetch_year_page(year)
+        if html is None:
+            continue
+        combined.extend(parse_resolution_rows(html))
 
-#f = open('UNSC.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in list_of_contents))
-#f.close
+    return combined
+
+
+def main() -> None:
+    print(scrape_unsc_resolutions())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/scrape_unsc_bk.py
+++ b/python/scrape_unsc_bk.py
@@ -1,77 +1,97 @@
 #!/usr/bin/env python3
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
+"""
+Scrape UN Security Council adopted resolutions listings (alternate TLS path).
 
-# Or download the file
-# http://www.py4e.com/code3/bs4.zip
-# and unzip it in the same directory as this file
+Same parsing logic as scrape_unsc.py but always passes an explicit SSL context
+to urllib when opening year index pages.
 
-import urllib.request
-import urllib.parse
-import urllib.error
-from bs4 import BeautifulSoup
-import ssl
+Dependencies: beautifulsoup4
+"""
+
+from __future__ import annotations
+
 import datetime
+import ssl
+import urllib.error
+import urllib.request
 
-# Ignore SSL certificate errors
-ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
+from bs4 import BeautifulSoup
 
-today = datetime.datetime.now()
-output = []
+YEARS_TO_FETCH = 2
+LIST_PATH = (
+    "https://www.un.org/securitycouncil/content/resolutions-adopted-security-council-"
+)
 
-count = 0
-while count < 2:
-    year = today.year + count
-    url = 'https://www.un.org/securitycouncil/content/resolutions-adopted-security-council-'+str(year)
+
+def create_unverified_ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def fetch_year_page(year: int, ssl_context: ssl.SSLContext) -> bytes | None:
+    url = f"{LIST_PATH}{year}"
     try:
-        html = urllib.request.urlopen(url, context=ctx).read()
-    except urllib.error.HTTPError as e:
-        if e.getcode() == 404: # check the return code
-            count = count + 1
-            continue
-        raise # if other than 404, raise the error
+        with urllib.request.urlopen(url, context=ssl_context) as response:
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
 
-    soup = BeautifulSoup(html, 'html.parser')
 
-    section = soup.find("div", {'class': 'field-items'})
-    trs = section.findAll('tr')
+def parse_resolution_rows(html: bytes) -> list[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    section = soup.find("div", {"class": "field-items"})
+    if not section:
+        return []
 
-    for tr in trs:
-        tds = tr.findAll('td')
-        title = []
-        contents = []
-        for id, td in enumerate(tds):          
-                if td.find('a') is not None and id == 0: 
-                    contents.append(td.getText().strip())
-                    contents.append(td.find('a').get('href'))
-                else:
-                    contents.append(td.getText().split("\n")[0])
+    output: list[str] = []
+    for row in section.find_all("tr"):
+        cells = row.find_all("td")
+        contents: list[str] = []
+        for col_idx, cell in enumerate(cells):
+            anchor = cell.find("a")
+            if anchor is not None and col_idx == 0:
+                contents.append(cell.getText().strip())
+                contents.append(anchor.get("href") or "")
+            else:
+                parts = cell.getText().split("\n")
+                contents.append(parts[0] if parts else "")
+
         contents.reverse()
-        
-        if contents:
-            title = contents[0].replace(u'\xa0', u' ')
-            title = title.replace("'", " ")
-            title = contents[3] + " - " + title
-            desc = contents[0] + " \n" + contents[2] + " \n" + contents[1]
-            desc = desc.replace("'", " ")
+        if not contents:
+            continue
 
-            output.append(title)
-            output.append(desc)
+        title = contents[0].replace("\xa0", " ").replace("'", " ")
+        title = contents[3] + " - " + title
+        desc = contents[0] + " \n" + contents[2] + " \n" + contents[1]
+        desc = desc.replace("'", " ")
+        output.append(title)
+        output.append(desc)
 
-    count = count + 1
+    return output
 
-#print(refs)
-#list_of_contents.reverse()
 
-#headings = list_of_contents[0::4]
-#URL = list_of_contents[2::4]
+def scrape_unsc_resolutions() -> list[str]:
+    ctx = create_unverified_ssl_context()
+    today = datetime.datetime.now()
+    combined: list[str] = []
 
-print(output)
-#print(headings)
-#print(URL)
+    for offset in range(YEARS_TO_FETCH):
+        year = today.year + offset
+        html = fetch_year_page(year, ctx)
+        if html is None:
+            continue
+        combined.extend(parse_resolution_rows(html))
 
-#f = open('UNSC.txt', 'w', encoding='utf-8', errors='replace')
-#f.write("\n".join(str(item) for item in list_of_contents))
-#f.close
+    return combined
+
+
+def main() -> None:
+    print(scrape_unsc_resolutions())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Refactors all `python/scrape_*.py` scripts for clearer structure: module docstrings, `main()` + `if __name__ == "__main__"`, constants, and small focused functions where it helped.
- Preserves each script’s existing stdout contract (flat `list` vs `json.dumps` dict, including `ensure_ascii=False` where used before).
- Removes dead comments/imports and fixes minor issues (e.g. variable shadowing, duplicate imports in `scrape_AU.py`).

## Test plan
- [ ] `python3 -m py_compile python/scrape_*.py`
- [ ] Spot-run any scrapers you rely on in CI or cron and confirm output shape unchanged for consumers.

Made with [Cursor](https://cursor.com)